### PR TITLE
Add MVC common utilities.

### DIFF
--- a/Common.sln
+++ b/Common.sln
@@ -1,0 +1,57 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FEAA3936-5906-4383-B750-F07FE1B156C5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.NotNullAttribute.Internal", "src\Microsoft.Framework.NotNullAttribute.Internal\Microsoft.Framework.NotNullAttribute.Internal.kproj", "{F399199B-6ACB-4E17-B1A3-3A3355B87E2E}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.CopyOnWriteDictionary.Internal", "src\Microsoft.Framework.CopyOnWriteDictionary.Internal\Microsoft.Framework.CopyOnWriteDictionary.Internal.kproj", "{D4BBCB55-914F-4BB3-922F-759FCC8C7728}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.PropertyActivator.Internal", "src\Microsoft.Framework.PropertyActivator.Internal\Microsoft.Framework.PropertyActivator.Internal.kproj", "{7068BBDB-B932-426B-897D-11F24F9FF578}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.PropertyHelper.Internal", "src\Microsoft.Framework.PropertyHelper.Internal\Microsoft.Framework.PropertyHelper.Internal.kproj", "{A5EAE14C-F682-44BB-9CB0-68E3992534D0}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Internal.Test", "test\Microsoft.Framework.Internal.Test\Microsoft.Framework.Internal.Test.kproj", "{D81EAC23-B515-49FB-B04B-285A9C1C6583}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F399199B-6ACB-4E17-B1A3-3A3355B87E2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F399199B-6ACB-4E17-B1A3-3A3355B87E2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F399199B-6ACB-4E17-B1A3-3A3355B87E2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F399199B-6ACB-4E17-B1A3-3A3355B87E2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4BBCB55-914F-4BB3-922F-759FCC8C7728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4BBCB55-914F-4BB3-922F-759FCC8C7728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4BBCB55-914F-4BB3-922F-759FCC8C7728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4BBCB55-914F-4BB3-922F-759FCC8C7728}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7068BBDB-B932-426B-897D-11F24F9FF578}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7068BBDB-B932-426B-897D-11F24F9FF578}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7068BBDB-B932-426B-897D-11F24F9FF578}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7068BBDB-B932-426B-897D-11F24F9FF578}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5EAE14C-F682-44BB-9CB0-68E3992534D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5EAE14C-F682-44BB-9CB0-68E3992534D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5EAE14C-F682-44BB-9CB0-68E3992534D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5EAE14C-F682-44BB-9CB0-68E3992534D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D81EAC23-B515-49FB-B04B-285A9C1C6583}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D81EAC23-B515-49FB-B04B-285A9C1C6583}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D81EAC23-B515-49FB-B04B-285A9C1C6583}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D81EAC23-B515-49FB-B04B-285A9C1C6583}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F399199B-6ACB-4E17-B1A3-3A3355B87E2E} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{D4BBCB55-914F-4BB3-922F-759FCC8C7728} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{7068BBDB-B932-426B-897D-11F24F9FF578} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{A5EAE14C-F682-44BB-9CB0-68E3992534D0} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{D81EAC23-B515-49FB-B04B-285A9C1C6583} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
+	EndGlobalSection
+EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "sources": ["src"]
+    "sources": ["src", "test"]
 }

--- a/src/Microsoft.Framework.CopyOnWriteDictionary.Internal/CopyOnWriteDictionary.cs
+++ b/src/Microsoft.Framework.CopyOnWriteDictionary.Internal/CopyOnWriteDictionary.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Framework.Internal
+{
+    internal class CopyOnWriteDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> _sourceDictionary;
+        private readonly IEqualityComparer<TKey> _comparer;
+        private IDictionary<TKey, TValue> _innerDictionary;
+
+        public CopyOnWriteDictionary([NotNull] IDictionary<TKey, TValue> sourceDictionary,
+                                     [NotNull] IEqualityComparer<TKey> comparer)
+        {
+            _sourceDictionary = sourceDictionary;
+            _comparer = comparer;
+        }
+
+        private IDictionary<TKey, TValue> ReadDictionary
+        {
+            get
+            {
+                return _innerDictionary ?? _sourceDictionary;
+            }
+        }
+
+        private IDictionary<TKey, TValue> WriteDictionary
+        {
+            get
+            {
+                if (_innerDictionary == null)
+                {
+                    _innerDictionary = new Dictionary<TKey, TValue>(_sourceDictionary,
+                                                                    _comparer);
+                }
+
+                return _innerDictionary;
+            }
+        }
+
+        public virtual ICollection<TKey> Keys
+        {
+            get
+            {
+                return ReadDictionary.Keys;
+            }
+        }
+
+        public virtual ICollection<TValue> Values
+        {
+            get
+            {
+                return ReadDictionary.Values;
+            }
+        }
+
+        public virtual int Count
+        {
+            get
+            {
+                return ReadDictionary.Count;
+            }
+        }
+
+        public virtual bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public virtual TValue this[[NotNull] TKey key]
+        {
+            get
+            {
+                return ReadDictionary[key];
+            }
+            set
+            {
+                WriteDictionary[key] = value;
+            }
+        }
+
+        public virtual bool ContainsKey([NotNull] TKey key)
+        {
+            return ReadDictionary.ContainsKey(key);
+        }
+
+        public virtual void Add([NotNull] TKey key, TValue value)
+        {
+            WriteDictionary.Add(key, value);
+        }
+
+        public virtual bool Remove([NotNull] TKey key)
+        {
+            return WriteDictionary.Remove(key);
+        }
+
+        public virtual bool TryGetValue([NotNull] TKey key, out TValue value)
+        {
+            return ReadDictionary.TryGetValue(key, out value);
+        }
+
+        public virtual void Add(KeyValuePair<TKey, TValue> item)
+        {
+            WriteDictionary.Add(item);
+        }
+
+        public virtual void Clear()
+        {
+            WriteDictionary.Clear();
+        }
+
+        public virtual bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ReadDictionary.Contains(item);
+        }
+
+        public virtual void CopyTo([NotNull] KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ReadDictionary.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return WriteDictionary.Remove(item);
+        }
+
+        public virtual IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return ReadDictionary.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Microsoft.Framework.CopyOnWriteDictionary.Internal/Microsoft.Framework.CopyOnWriteDictionary.Internal.kproj
+++ b/src/Microsoft.Framework.CopyOnWriteDictionary.Internal/Microsoft.Framework.CopyOnWriteDictionary.Internal.kproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d4bbcb55-914f-4bb3-922f-759fcc8c7728</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Framework.CopyOnWriteDictionary.Internal/project.json
+++ b/src/Microsoft.Framework.CopyOnWriteDictionary.Internal/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "shared": "*.cs",
+    "dependencies": {
+    },
+    "frameworks": {
+        "net45": { },
+        "aspnet50": { },
+        "aspnetcore50": {
+            "dependencies": {
+                "System.Runtime": "4.0.20-*"
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.NotNullAttribute.Internal/Microsoft.Framework.NotNullAttribute.Internal.kproj
+++ b/src/Microsoft.Framework.NotNullAttribute.Internal/Microsoft.Framework.NotNullAttribute.Internal.kproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f399199b-6acb-4e17-b1a3-3a3355b87e2e</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Framework.NotNullAttribute.Internal/NotNullAttribute.cs
+++ b/src/Microsoft.Framework.NotNullAttribute.Internal/NotNullAttribute.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Framework.Internal
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    internal sealed class NotNullAttribute : Attribute
+    {
+    }
+}

--- a/src/Microsoft.Framework.NotNullAttribute.Internal/project.json
+++ b/src/Microsoft.Framework.NotNullAttribute.Internal/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "shared": "*.cs",
+    "dependencies": {
+    },
+    "frameworks": {
+        "net45": { },
+        "aspnet50": { },
+        "aspnetcore50": {
+            "dependencies": {
+                "System.Runtime": "4.0.20-*"
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.PropertyActivator.Internal/Microsoft.Framework.PropertyActivator.Internal.kproj
+++ b/src/Microsoft.Framework.PropertyActivator.Internal/Microsoft.Framework.PropertyActivator.Internal.kproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>7068bbdb-b932-426b-897d-11f24f9ff578</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Framework.PropertyActivator.Internal/PropertyActivator.cs
+++ b/src/Microsoft.Framework.PropertyActivator.Internal/PropertyActivator.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Framework.Internal
+{
+    internal class PropertyActivator<TContext>
+    {
+        private readonly Func<TContext, object> _valueAccessor;
+        private readonly Action<object, object> _fastPropertySetter;
+
+        public PropertyActivator([NotNull] PropertyInfo propertyInfo,
+                                 [NotNull] Func<TContext, object> valueAccessor)
+        {
+            PropertyInfo = propertyInfo;
+            _valueAccessor = valueAccessor;
+            _fastPropertySetter = PropertyHelper.MakeFastPropertySetter(propertyInfo);
+        }
+
+        public PropertyInfo PropertyInfo { get; private set; }
+
+        public object Activate([NotNull] object view, [NotNull] TContext context)
+        {
+            var value = _valueAccessor(context);
+            _fastPropertySetter(view, value);
+            return value;
+        }
+
+        public static PropertyActivator<TContext>[] GetPropertiesToActivate(
+            [NotNull] Type type,
+            [NotNull] Type activateAttributeType,
+            [NotNull] Func<PropertyInfo, PropertyActivator<TContext>> createActivateInfo)
+        {
+            return type.GetRuntimeProperties()
+                       .Where(property =>
+                              property.IsDefined(activateAttributeType) &&
+                              property.GetIndexParameters().Length == 0 &&
+                              property.SetMethod != null &&
+                              !property.SetMethod.IsStatic)
+                       .Select(createActivateInfo)
+                       .ToArray();
+        }
+    }
+}

--- a/src/Microsoft.Framework.PropertyActivator.Internal/project.json
+++ b/src/Microsoft.Framework.PropertyActivator.Internal/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "shared": "*.cs",
+    "dependencies": {
+    },
+    "frameworks": {
+        "net45": { },
+        "aspnet50": { },
+        "aspnetcore50": {
+            "dependencies": {
+                "System.Runtime": "4.0.20-*"
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.PropertyHelper.Internal/Microsoft.Framework.PropertyHelper.Internal.kproj
+++ b/src/Microsoft.Framework.PropertyHelper.Internal/Microsoft.Framework.PropertyHelper.Internal.kproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a5eae14c-f682-44bb-9cb0-68e3992534d0</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Framework.PropertyHelper.Internal/PropertyHelper.cs
+++ b/src/Microsoft.Framework.PropertyHelper.Internal/PropertyHelper.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Framework.Internal
+{
+    internal class PropertyHelper
+    {
+        // Delegate type for a by-ref property getter
+        private delegate TValue ByRefFunc<TDeclaringType, TValue>(ref TDeclaringType arg);
+
+        private static readonly MethodInfo CallPropertyGetterOpenGenericMethod =
+            typeof(PropertyHelper).GetTypeInfo().GetDeclaredMethod("CallPropertyGetter");
+
+        private static readonly MethodInfo CallPropertyGetterByReferenceOpenGenericMethod =
+            typeof(PropertyHelper).GetTypeInfo().GetDeclaredMethod("CallPropertyGetterByReference");
+
+        private static readonly MethodInfo CallPropertySetterOpenGenericMethod =
+            typeof(PropertyHelper).GetTypeInfo().GetDeclaredMethod("CallPropertySetter");
+
+        private static readonly ConcurrentDictionary<Type, PropertyHelper[]> ReflectionCache =
+            new ConcurrentDictionary<Type, PropertyHelper[]>();
+
+        private readonly Func<object, object> _valueGetter;
+
+        /// <summary>
+        /// Initializes a fast <see cref="PropertyHelper"/>.
+        /// This constructor does not cache the helper. For caching, use <see cref="GetProperties(object)"/>.
+        /// </summary>
+        public PropertyHelper([NotNull] PropertyInfo property)
+        {
+            Property = property;
+            Name = property.Name;
+            _valueGetter = MakeFastPropertyGetter(property);
+        }
+
+        public PropertyInfo Property { get; private set; }
+
+        public virtual string Name { get; protected set; }
+
+        public object GetValue(object instance)
+        {
+            return _valueGetter(instance);
+        }
+
+        /// <summary>
+        /// Creates and caches fast property helpers that expose getters for every public get property on the
+        /// underlying type.
+        /// </summary>
+        /// <param name="instance">the instance to extract property accessors for.</param>
+        /// <returns>a cached array of all public property getters from the underlying type of target instance.
+        /// </returns>
+        public static PropertyHelper[] GetProperties(object instance)
+        {
+            return GetProperties(instance.GetType());
+        }
+
+        /// <summary>
+        /// Creates and caches fast property helpers that expose getters for every public get property on the
+        /// specified type.
+        /// </summary>
+        /// <param name="type">the type to extract property accessors for.</param>
+        /// <returns>a cached array of all public property getters from the type of target instance.
+        /// </returns>
+        public static PropertyHelper[] GetProperties(Type type)
+        {
+            return GetProperties(type, CreateInstance, ReflectionCache);
+        }
+
+        /// <summary>
+        /// Creates a single fast property getter. The result is not cached.
+        /// </summary>
+        /// <param name="propertyInfo">propertyInfo to extract the getter for.</param>
+        /// <returns>a fast getter.</returns>
+        /// <remarks>
+        /// This method is more memory efficient than a dynamically compiled lambda, and about the
+        /// same speed.
+        /// </remarks>
+        public static Func<object, object> MakeFastPropertyGetter(PropertyInfo propertyInfo)
+        {
+            Debug.Assert(propertyInfo != null);
+
+            var getMethod = propertyInfo.GetMethod;
+            Debug.Assert(getMethod != null);
+            Debug.Assert(!getMethod.IsStatic);
+            Debug.Assert(getMethod.GetParameters().Length == 0);
+
+            // Instance methods in the CLR can be turned into static methods where the first parameter
+            // is open over "target". This parameter is always passed by reference, so we have a code
+            // path for value types and a code path for reference types.
+            var typeInput = getMethod.DeclaringType;
+            var typeOutput = getMethod.ReturnType;
+
+            Delegate callPropertyGetterDelegate;
+            if (typeInput.GetTypeInfo().IsValueType)
+            {
+                // Create a delegate (ref TDeclaringType) -> TValue
+                var delegateType = typeof(ByRefFunc<,>).MakeGenericType(typeInput, typeOutput);
+                var propertyGetterAsFunc = getMethod.CreateDelegate(delegateType);
+                var callPropertyGetterClosedGenericMethod =
+                    CallPropertyGetterByReferenceOpenGenericMethod.MakeGenericMethod(typeInput, typeOutput);
+                callPropertyGetterDelegate =
+                    callPropertyGetterClosedGenericMethod.CreateDelegate(
+                        typeof(Func<object, object>), propertyGetterAsFunc);
+            }
+            else
+            {
+                // Create a delegate TDeclaringType -> TValue
+                var propertyGetterAsFunc =
+                    getMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(typeInput, typeOutput));
+                var callPropertyGetterClosedGenericMethod =
+                    CallPropertyGetterOpenGenericMethod.MakeGenericMethod(typeInput, typeOutput);
+                callPropertyGetterDelegate =
+                    callPropertyGetterClosedGenericMethod.CreateDelegate(
+                        typeof(Func<object, object>), propertyGetterAsFunc);
+            }
+
+            return (Func<object, object>)callPropertyGetterDelegate;
+        }
+
+        /// <summary>
+        /// Creates a single fast property setter for reference types. The result is not cached.
+        /// </summary>
+        /// <param name="propertyInfo">propertyInfo to extract the setter for.</param>
+        /// <returns>a fast getter.</returns>
+        /// <remarks>
+        /// This method is more memory efficient than a dynamically compiled lambda, and about the
+        /// same speed. This only works for reference types.
+        /// </remarks>
+        public static Action<object, object> MakeFastPropertySetter(PropertyInfo propertyInfo)
+        {
+            Debug.Assert(propertyInfo != null);
+            Debug.Assert(!propertyInfo.DeclaringType.GetTypeInfo().IsValueType);
+
+            var setMethod = propertyInfo.SetMethod;
+            Debug.Assert(setMethod != null);
+            Debug.Assert(!setMethod.IsStatic);
+            Debug.Assert(setMethod.ReturnType == typeof(void));
+            var parameters = setMethod.GetParameters();
+            Debug.Assert(parameters.Length == 1);
+
+            // Instance methods in the CLR can be turned into static methods where the first parameter
+            // is open over "target". This parameter is always passed by reference, so we have a code
+            // path for value types and a code path for reference types.
+            var typeInput = setMethod.DeclaringType;
+            var parameterType = parameters[0].ParameterType;
+
+            // Create a delegate TDeclaringType -> { TDeclaringType.Property = TValue; }
+            var propertySetterAsAction =
+                setMethod.CreateDelegate(typeof(Action<,>).MakeGenericType(typeInput, parameterType));
+            var callPropertySetterClosedGenericMethod =
+                CallPropertySetterOpenGenericMethod.MakeGenericMethod(typeInput, parameterType);
+            var callPropertySetterDelegate =
+                callPropertySetterClosedGenericMethod.CreateDelegate(
+                    typeof(Action<object, object>), propertySetterAsAction);
+
+            return (Action<object, object>)callPropertySetterDelegate;
+        }
+
+        private static PropertyHelper CreateInstance(PropertyInfo property)
+        {
+            return new PropertyHelper(property);
+        }
+
+        // Called via reflection
+        private static object CallPropertyGetter<TDeclaringType, TValue>(
+            Func<TDeclaringType, TValue> getter,
+            object target)
+        {
+            return getter((TDeclaringType)target);
+        }
+
+        // Called via reflection
+        private static object CallPropertyGetterByReference<TDeclaringType, TValue>(
+            ByRefFunc<TDeclaringType, TValue> getter,
+            object target)
+        {
+            var unboxed = (TDeclaringType)target;
+            return getter(ref unboxed);
+        }
+
+        private static void CallPropertySetter<TDeclaringType, TValue>(
+            Action<TDeclaringType, TValue> setter,
+            object target,
+            object value)
+        {
+            setter((TDeclaringType)target, (TValue)value);
+        }
+
+        protected static PropertyHelper[] GetProperties(
+            Type type,
+            Func<PropertyInfo, PropertyHelper> createPropertyHelper,
+            ConcurrentDictionary<Type, PropertyHelper[]> cache)
+        {
+            // Unwrap nullable types. This means Nullable<T>.Value and Nullable<T>.HasValue will not be
+            // part of the sequence of properties returned by this method.
+            type = Nullable.GetUnderlyingType(type) ?? type;
+
+            // Using an array rather than IEnumerable, as target will be called on the hot path numerous times.
+            PropertyHelper[] helpers;
+
+            if (!cache.TryGetValue(type, out helpers))
+            {
+                // We avoid loading indexed properties using the where statement.
+                // Indexed properties are not useful (or valid) for grabbing properties off an object.
+                var properties = type.GetRuntimeProperties().Where(
+                    prop => prop.GetIndexParameters().Length == 0 &&
+                    prop.GetMethod != null &&
+                    prop.GetMethod.IsPublic &&
+                    !prop.GetMethod.IsStatic);
+
+                helpers = properties.Select(p => createPropertyHelper(p)).ToArray();
+                cache.TryAdd(type, helpers);
+            }
+
+            return helpers;
+        }
+    }
+}

--- a/src/Microsoft.Framework.PropertyHelper.Internal/project.json
+++ b/src/Microsoft.Framework.PropertyHelper.Internal/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "shared": "*.cs",
+    "dependencies": {
+    },
+    "frameworks": {
+        "net45": { },
+        "aspnet50": { },
+        "aspnetcore50": {
+            "dependencies": {
+                "System.Runtime": "4.0.20-*"
+            }
+        }
+    }
+}

--- a/test/Microsoft.Framework.Internal.Test/CopyOnWriteDictionaryTest.cs
+++ b/test/Microsoft.Framework.Internal.Test/CopyOnWriteDictionaryTest.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+#if !ASPNETCORE50
+using Moq;
+#endif
+using Xunit;
+
+namespace Microsoft.Framework.Internal
+{
+    public class CopyOnWriteDictionaryTest
+    {
+#if !ASPNETCORE50
+        [Fact]
+        public void ReadOperation_DelegatesToSourceDictionary_IfNoMutationsArePerformed()
+        {
+            // Arrange
+            var values = new List<object>();
+            var enumerator = Mock.Of<IEnumerator<KeyValuePair<string, object>>>();
+            var sourceDictionary = new Mock<IDictionary<string, object>>(MockBehavior.Strict);
+            sourceDictionary.SetupGet(d => d.Count)
+                            .Returns(100)
+                            .Verifiable();
+            sourceDictionary.SetupGet(d => d.Values)
+                            .Returns(values)
+                            .Verifiable();
+            sourceDictionary.Setup(d => d.ContainsKey("test-key"))
+                            .Returns(value: true)
+                            .Verifiable();
+            sourceDictionary.Setup(d => d.GetEnumerator())
+                            .Returns(enumerator)
+                            .Verifiable();
+            sourceDictionary.Setup(d => d["key2"])
+                            .Returns("key2-value")
+                            .Verifiable();
+            object value;
+            sourceDictionary.Setup(d => d.TryGetValue("different-key", out value))
+                            .Returns(false)
+                            .Verifiable();
+
+            var copyOnWriteDictionary = new CopyOnWriteDictionary<string, object>(sourceDictionary.Object,
+                                                                                  StringComparer.OrdinalIgnoreCase);
+
+            // Act and Assert
+            Assert.Equal("key2-value", copyOnWriteDictionary["key2"]);
+            Assert.Equal(100, copyOnWriteDictionary.Count);
+            Assert.Same(values, copyOnWriteDictionary.Values);
+            Assert.True(copyOnWriteDictionary.ContainsKey("test-key"));
+            Assert.Same(enumerator, copyOnWriteDictionary.GetEnumerator());
+            Assert.False(copyOnWriteDictionary.TryGetValue("different-key", out value));
+            sourceDictionary.Verify();
+        }
+#endif
+
+        [Fact]
+        public void ReadOperation_DoesNotDelegateToSourceDictionary_OnceAValueIsChanged()
+        {
+            // Arrange
+            var values = new List<object>();
+            var sourceDictionary = new Dictionary<string, object>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            var copyOnWriteDictionary = new CopyOnWriteDictionary<string, object>(sourceDictionary,
+                                                                                  StringComparer.OrdinalIgnoreCase);
+
+            // Act
+            copyOnWriteDictionary["key2"] = "value3";
+
+            // Assert
+            Assert.Equal("value2", sourceDictionary["key2"]);
+            Assert.Equal(2, copyOnWriteDictionary.Count);
+            Assert.Equal("value1", copyOnWriteDictionary["key1"]);
+            Assert.Equal("value3", copyOnWriteDictionary["key2"]);
+        }
+
+        [Fact]
+        public void ReadOperation_DoesNotDelegateToSourceDictionary_OnceDictionaryIsModified()
+        {
+            // Arrange
+            var values = new List<object>();
+            var sourceDictionary = new Dictionary<string, object>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            var copyOnWriteDictionary = new CopyOnWriteDictionary<string, object>(sourceDictionary,
+                                                                                  StringComparer.OrdinalIgnoreCase);
+
+            // Act
+            copyOnWriteDictionary.Add("key3", "value3");
+            copyOnWriteDictionary.Remove("key1");
+
+
+            // Assert
+            Assert.Equal(2, sourceDictionary.Count);
+            Assert.Equal("value1", sourceDictionary["key1"]);
+            Assert.Equal(2, copyOnWriteDictionary.Count);
+            Assert.Equal("value2", copyOnWriteDictionary["KeY2"]);
+            Assert.Equal("value3", copyOnWriteDictionary["key3"]);
+        }
+    }
+}

--- a/test/Microsoft.Framework.Internal.Test/Microsoft.Framework.Internal.Test.kproj
+++ b/test/Microsoft.Framework.Internal.Test/Microsoft.Framework.Internal.Test.kproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d81eac23-b515-49fb-b04b-285a9c1c6583</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Framework.Internal.Test/PropertyActivatorTest.cs
+++ b/test/Microsoft.Framework.Internal.Test/PropertyActivatorTest.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Framework.Internal
+{
+    public class PropertyActivatorTest
+    {
+        [Fact]
+        public void Activate_InvokesValueAccessorWithExpectedValue()
+        {
+            // Arrange
+            var instance = new TestClass();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var property = typeInfo.GetDeclaredProperty("IntProperty");
+            var invokedWith = -1;
+            var activator = new PropertyActivator<int>(
+                property,
+                valueAccessor: (val) =>
+                {
+                    invokedWith = val;
+                    return val;
+                });
+
+            // Act
+            activator.Activate(instance, 123);
+
+            // Assert
+            Assert.Equal(123, invokedWith);
+        }
+
+        [Fact]
+        public void Activate_SetsPropertyValue()
+        {
+            // Arrange
+            var instance = new TestClass();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var property = typeInfo.GetDeclaredProperty("IntProperty");
+            var activator = new PropertyActivator<int>(property, valueAccessor: (val) => val + 1);
+
+            // Act
+            activator.Activate(instance, 123);
+
+            // Assert
+            Assert.Equal(124, instance.IntProperty);
+        }
+
+        [Fact]
+        public void GetPropertiesToActivate_RestrictsActivatableProperties()
+        {
+            // Arrange
+            var instance = new TestClass();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var expectedPropertyInfo = typeInfo.GetDeclaredProperty("ActivatableProperty");
+
+            // Act
+            var propertiesToActivate = PropertyActivator<int>.GetPropertiesToActivate(
+                type: typeof(TestClass),
+                activateAttributeType: typeof(TestActivateAttribute),
+                createActivateInfo:
+                (propertyInfo) => new PropertyActivator<int>(propertyInfo, valueAccessor: (val) => val + 1));
+
+            // Assert
+            Assert.Collection(
+                propertiesToActivate,
+                (activator) =>
+                {
+                    Assert.Equal(expectedPropertyInfo, activator.PropertyInfo);
+                });
+        }
+
+        [Fact]
+        public void GetPropertiesToActivate_CanCreateCustomPropertyActivators()
+        {
+            // Arrange
+            var instance = new TestClass();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var expectedPropertyInfo = typeInfo.GetDeclaredProperty("IntProperty");
+
+            // Act
+            var propertiesToActivate = PropertyActivator<int>.GetPropertiesToActivate(
+                type: typeof(TestClass),
+                activateAttributeType: typeof(TestActivateAttribute),
+                createActivateInfo:
+                (propertyInfo) => new PropertyActivator<int>(expectedPropertyInfo, valueAccessor: (val) => val + 1));
+
+            // Assert
+            Assert.Collection(
+                propertiesToActivate,
+                (activator) =>
+                {
+                    Assert.Equal(expectedPropertyInfo, activator.PropertyInfo);
+                });
+        }
+
+        private class TestClass
+        {
+            public int IntProperty { get; set; }
+
+            [TestActivate]
+            public int ActivatableProperty { get; set; }
+
+            [TestActivate]
+            public int NoSetterActivatableProperty { get; }
+
+            [TestActivate]
+            public int this[int something] // Not activatable
+            {
+                get
+                {
+                    return 0;
+                }
+            }
+
+            [TestActivate]
+            public static int StaticActivatablProperty { get; set; }
+        }
+
+        [AttributeUsage(AttributeTargets.Property)]
+        private class TestActivateAttribute : Attribute
+        {
+        }
+
+        private class ActivationInfo
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Framework.Internal.Test/PropertyHelperTest.cs
+++ b/test/Microsoft.Framework.Internal.Test/PropertyHelperTest.cs
@@ -1,0 +1,393 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNet.Testing;
+using Xunit;
+
+namespace Microsoft.Framework.Internal
+{
+    public class PropertyHelperTest
+    {
+        [Fact]
+        public void PropertyHelper_ReturnsNameCorrectly()
+        {
+            // Arrange
+            var anonymous = new { foo = "bar" };
+            var property = PropertyHelper.GetProperties(anonymous.GetType()).First().Property;
+
+            // Act
+            var helper = new PropertyHelper(property);
+
+            // Assert
+            Assert.Equal("foo", property.Name);
+            Assert.Equal("foo", helper.Name);
+        }
+
+        [Fact]
+        public void PropertyHelper_ReturnsValueCorrectly()
+        {
+            // Arrange
+            var anonymous = new { bar = "baz" };
+            var property = PropertyHelper.GetProperties(anonymous.GetType()).First().Property;
+
+            // Act
+            var helper = new PropertyHelper(property);
+
+            // Assert
+            Assert.Equal("bar", helper.Name);
+            Assert.Equal("baz", helper.GetValue(anonymous));
+        }
+
+        [Fact]
+        public void PropertyHelper_ReturnsValueCorrectly_ForValueTypes()
+        {
+            // Arrange
+            var anonymous = new { foo = 32 };
+            var property = PropertyHelper.GetProperties(anonymous.GetType()).First().Property;
+
+            // Act
+            var helper = new PropertyHelper(property);
+
+            // Assert
+            Assert.Equal("foo", helper.Name);
+            Assert.Equal(32, helper.GetValue(anonymous));
+        }
+
+        [Fact]
+        public void PropertyHelper_ReturnsCachedPropertyHelper()
+        {
+            // Arrange
+            var anonymous = new { foo = "bar" };
+
+            // Act
+            var helpers1 = PropertyHelper.GetProperties(anonymous);
+            var helpers2 = PropertyHelper.GetProperties(anonymous);
+
+            // Assert
+            Assert.Equal(1, helpers1.Length);
+            Assert.Same(helpers1, helpers2);
+            Assert.Same(helpers1[0], helpers2[0]);
+        }
+
+        [Fact]
+        public void PropertyHelper_DoesNotChangeUnderscores()
+        {
+            // Arrange
+            var anonymous = new { bar_baz2 = "foo" };
+
+            // Act + Assert
+            var helper = Assert.Single(PropertyHelper.GetProperties(anonymous));
+            Assert.Equal("bar_baz2", helper.Name);
+        }
+
+        [Fact]
+        public void PropertyHelper_DoesNotFindPrivateProperties()
+        {
+            // Arrange
+            var anonymous = new PrivateProperties();
+
+            // Act + Assert
+            var helper = Assert.Single(PropertyHelper.GetProperties(anonymous));
+            Assert.Equal("Prop1", helper.Name);
+        }
+
+        [Fact]
+        public void PropertyHelper_DoesNotFindStaticProperties()
+        {
+            // Arrange
+            var anonymous = new Static();
+
+            // Act + Assert
+            var helper = Assert.Single(PropertyHelper.GetProperties(anonymous));
+            Assert.Equal("Prop5", helper.Name);
+        }
+
+        [Fact]
+        public void PropertyHelper_DoesNotFindSetOnlyProperties()
+        {
+            // Arrange
+            var anonymous = new SetOnly();
+
+            // Act + Assert
+            var helper = Assert.Single(PropertyHelper.GetProperties(anonymous));
+            Assert.Equal("Prop6", helper.Name);
+        }
+
+        [Theory]
+        [InlineData(typeof(int?))]
+        [InlineData(typeof(DayOfWeek?))]
+        public void PropertyHelper_WorksForNullablePrimitiveAndEnumTypes(Type nullableType)
+        {
+            // Act
+            var properties = PropertyHelper.GetProperties(nullableType);
+
+            // Assert
+            Assert.Empty(properties);
+        }
+
+        [Fact]
+        public void PropertyHelper_UnwrapsNullableTypes()
+        {
+            // Arrange
+            var myType = typeof(MyStruct?);
+
+            // Act
+            var properties = PropertyHelper.GetProperties(myType);
+
+            // Assert
+            var property = Assert.Single(properties);
+            Assert.Equal("Foo", property.Name);
+        }
+
+        [Fact]
+        public void PropertyHelper_WorksForStruct()
+        {
+            if (TestPlatformHelper.IsMono)
+            {
+                // PropertyHelper seems to be broken for value types on Mono.
+                return;
+            }
+
+            // Arrange
+            var anonymous = new MyProperties();
+
+            anonymous.IntProp = 3;
+            anonymous.StringProp = "Five";
+
+            // Act + Assert
+            var helper1 = Assert.Single(PropertyHelper.GetProperties(anonymous).Where(prop => prop.Name == "IntProp"));
+            var helper2 = Assert.Single(PropertyHelper.GetProperties(anonymous).Where(prop => prop.Name == "StringProp"));
+            Assert.Equal(3, helper1.GetValue(anonymous));
+            Assert.Equal("Five", helper2.GetValue(anonymous));
+        }
+
+        [Fact]
+        public void PropertyHelper_ForDerivedClass()
+        {
+            // Arrange
+            var derived = new DerivedClass { PropA = "propAValue", PropB = "propBValue" };
+
+            // Act
+            var helpers = PropertyHelper.GetProperties(derived).ToArray();
+
+            // Assert
+            Assert.NotNull(helpers);
+            Assert.Equal(2, helpers.Length);
+
+            var propAHelper = Assert.Single(helpers.Where(h => h.Name == "PropA"));
+            var propBHelper = Assert.Single(helpers.Where(h => h.Name == "PropB"));
+
+            Assert.Equal("propAValue", propAHelper.GetValue(derived));
+            Assert.Equal("propBValue", propBHelper.GetValue(derived));
+        }
+
+        [Fact]
+        public void PropertyHelper_ForDerivedClass_WithNew()
+        {
+            // Arrange
+            var derived = new DerivedClassWithNew { PropA = "propAValue" };
+
+            // Act
+            var helpers = PropertyHelper.GetProperties(derived).ToArray();
+
+            // Assert
+            Assert.NotNull(helpers);
+            Assert.Equal(2, helpers.Length);
+
+            var propAHelper = Assert.Single(helpers.Where(h => h.Name == "PropA"));
+            var propBHelper = Assert.Single(helpers.Where(h => h.Name == "PropB"));
+
+            Assert.Equal("propAValue", propAHelper.GetValue(derived));
+            Assert.Equal("Newed", propBHelper.GetValue(derived));
+        }
+
+        [Fact]
+        public void PropertyHelper_ForDerived_WithVirtual()
+        {
+            // Arrange
+            var derived = new DerivedClassWithOverride { PropA = "propAValue", PropB = "propBValue" };
+
+            // Act
+            var helpers = PropertyHelper.GetProperties(derived).ToArray();
+
+            // Assert
+            Assert.NotNull(helpers);
+            Assert.Equal(2, helpers.Length);
+
+            var propAHelper = Assert.Single(helpers.Where(h => h.Name == "PropA"));
+            var propBHelper = Assert.Single(helpers.Where(h => h.Name == "PropB"));
+
+            Assert.Equal("OverridenpropAValue", propAHelper.GetValue(derived));
+            Assert.Equal("propBValue", propBHelper.GetValue(derived));
+        }
+
+        [Fact]
+        public void GetProperties_ExcludesIndexersAndPropertiesWithoutPublicGetters()
+        {
+            // Arrange
+            var type = typeof(DerivedClassWithNonReadableProperties);
+
+
+            // Act
+            var result = PropertyHelper.GetProperties(type).ToArray();
+
+            // Assert
+            Assert.Equal(3, result.Length);
+            Assert.Equal("Visible", result[0].Name);
+            Assert.Equal("PropA", result[1].Name);
+            Assert.Equal("PropB", result[2].Name);
+        }
+
+        [Fact]
+        public void MakeFastPropertySetter_SetsPropertyValues_ForPublicAndNobPublicProperties()
+        {
+            // Arrange
+            var instance = new BaseClass();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var publicProperty = typeInfo.GetDeclaredProperty("PropA");
+            var protectedProperty = typeInfo.GetDeclaredProperty("PropProtected");
+            var publicPropertySetter = PropertyHelper.MakeFastPropertySetter(publicProperty);
+            var protectedPropertySetter = PropertyHelper.MakeFastPropertySetter(protectedProperty);
+
+            // Act
+            publicPropertySetter(instance, "TestPublic");
+            protectedPropertySetter(instance, "TestProtected");
+
+            // Assert
+            Assert.Equal("TestPublic", instance.PropA);
+            Assert.Equal("TestProtected", instance.GetPropProtected());
+        }
+
+        [Fact]
+        public void MakeFastPropertySetter_SetsPropertyValues_ForOverridenProperties()
+        {
+            // Arrange
+            var instance = new DerivedClassWithOverride();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var property = typeInfo.GetDeclaredProperty("PropA");
+            var propertySetter = PropertyHelper.MakeFastPropertySetter(property);
+
+            // Act
+            propertySetter(instance, "Test value");
+
+            // Assert
+            Assert.Equal("OverridenTest value", instance.PropA);
+        }
+
+        [Fact]
+        public void MakeFastPropertySetter_SetsPropertyValues_ForNewedProperties()
+        {
+            // Arrange
+            var instance = new DerivedClassWithNew();
+            var typeInfo = instance.GetType().GetTypeInfo();
+            var property = typeInfo.GetDeclaredProperty("PropB");
+            var propertySetter = PropertyHelper.MakeFastPropertySetter(property);
+
+            // Act
+            propertySetter(instance, "Test value");
+
+            // Assert
+            Assert.Equal("NewedTest value", instance.PropB);
+        }
+
+        private class Static
+        {
+            public static int Prop2 { get; set; }
+            public int Prop5 { get; set; }
+        }
+
+        private struct MyProperties
+        {
+            public int IntProp { get; set; }
+            public string StringProp { get; set; }
+        }
+
+        private class SetOnly
+        {
+            public int Prop2 { set { } }
+            public int Prop6 { get; set; }
+        }
+
+        private class PrivateProperties
+        {
+            public int Prop1 { get; set; }
+            protected int Prop2 { get; set; }
+            private int Prop3 { get; set; }
+        }
+
+        public class BaseClass
+        {
+            public string PropA { get; set; }
+
+            protected string PropProtected { get; set; }
+
+            public string GetPropProtected()
+            {
+                return PropProtected;
+            }
+        }
+
+        public class DerivedClass : BaseClass
+        {
+            public string PropB { get; set; }
+        }
+
+        public class BaseClassWithVirtual
+        {
+            public virtual string PropA { get; set; }
+            public string PropB { get; set; }
+        }
+
+        public class DerivedClassWithNew : BaseClassWithVirtual
+        {
+            private string _value = "Newed";
+
+            public new string PropB
+            {
+                get { return _value; }
+                set { _value = "Newed" + value; }
+            }
+        }
+
+        public class DerivedClassWithOverride : BaseClassWithVirtual
+        {
+            private string _value = "Overriden";
+
+            public override string PropA
+            {
+                get { return _value; }
+                set { _value = "Overriden" + value; }
+            }
+        }
+
+        private class DerivedClassWithNonReadableProperties : BaseClassWithVirtual
+        {
+            public string this[int index]
+            {
+                get { return string.Empty; }
+                set { }
+            }
+
+            public int Visible { get; set; }
+
+            private string NotVisible { get; set; }
+
+            public string NotVisible2 { private get; set; }
+
+            public string NotVisible3
+            {
+                set { }
+            }
+
+            public static string NotVisible4 { get; set; }
+        }
+
+        private struct MyStruct
+        {
+            public string Foo { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Framework.Internal.Test/project.json
+++ b/test/Microsoft.Framework.Internal.Test/project.json
@@ -1,0 +1,24 @@
+﻿{
+    "compilationOptions": {
+        "warningsAsErrors": "true"
+    },
+    "dependencies": {
+        "Microsoft.Framework.CopyOnWriteDictionary.Internal": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.NotNullAttribute.Internal": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.PropertyHelper.Internal": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.PropertyActivator.Internal": { "type": "build", "version": "1.0.0-*" },
+        "xunit.runner.kre": "1.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*"
+    },
+    "commands": {
+        "test": "xunit.runner.kre"
+    },
+    "frameworks": {
+        "aspnet50": {
+            "dependencies": {
+                "Moq": "4.2.1312.1622"
+            }
+        },
+        "aspnetcore50": { }
+    }
+}


### PR DESCRIPTION
**NOTE:** Ignore the utility classes and their corresponding tests. These were copied verbatim from Mvc and the only thing modified was their namespace.

- Added `NotNullAttribute`
- Added `PropertyActivator`
- Added `PropertyHelper`
- Added `CopyOnWriteDictionary`
- Added tests for `CopyOnWriteDictionary` and `PropertyHelper`. `PropertyActivator` did not have any tests in Mvc.
- Updated .gitignore to remove lock files.
- Updated global.json to include the test folder.

Working on a reaction PR to MVC.

For now users will have to manually include the shared source dependencies (ex: `CopyOnWriteDictionary` will require the `NotNullAttribute` package) until https://github.com/aspnet/XRE/issues/1237 is completed.