### PR TITLE
Add a null-safe version of the property accessor.

### DIFF
--- a/test/Microsoft.Framework.Internal.Test/PropertyHelperTest.cs
+++ b/test/Microsoft.Framework.Internal.Test/PropertyHelperTest.cs
@@ -193,12 +193,6 @@ namespace Microsoft.Framework.Internal
         [Fact]
         public void PropertyHelper_WorksForStruct()
         {
-            if (TestPlatformHelper.IsMono)
-            {
-                // PropertyHelper seems to be broken for value types on Mono.
-                return;
-            }
-
             // Arrange
             var anonymous = new MyProperties();
 
@@ -389,6 +383,102 @@ namespace Microsoft.Framework.Internal
 
             // Assert
             Assert.Equal("NewedTest value", instance.PropB);
+        }
+
+        [Fact]
+        public void MakeFastPropertyGetter_ReferenceType_ForNullObject_Throws()
+        {
+            // Arrange
+            var property = PropertyHelper
+                .GetProperties(typeof(BaseClass))
+                .Single(p => p.Name == nameof(BaseClass.PropA));
+
+            var accessor = PropertyHelper.MakeFastPropertyGetter(property.Property);
+
+            // Act & Assert
+            Assert.Throws<NullReferenceException>(() => accessor(null));
+        }
+
+        [Fact]
+        public void MakeFastPropertyGetter_ValueType_ForNullObject_Throws()
+        {
+            // Arrange
+            var property = PropertyHelper
+                .GetProperties(typeof(MyProperties))
+                .Single(p => p.Name == nameof(MyProperties.StringProp));
+
+            var accessor = PropertyHelper.MakeFastPropertyGetter(property.Property);
+
+            // Act & Assert
+            Assert.Throws<NullReferenceException>(() => accessor(null));
+        }
+
+        [Fact]
+        public void MakeNullSafeFastPropertyGetter_ReferenceType_Success()
+        {
+            // Arrange
+            var property = PropertyHelper
+                .GetProperties(typeof(BaseClass))
+                .Single(p => p.Name == nameof(BaseClass.PropA));
+
+            var accessor = PropertyHelper.MakeNullSafeFastPropertyGetter(property.Property);
+
+            // Act
+            var value = accessor(new BaseClass() { PropA = "Hi" });
+
+            // Assert
+            Assert.Equal("Hi", value);
+        }
+
+        [Fact]
+        public void MakeNullSafeFastPropertyGetter_ValueType_Success()
+        {
+            // Arrange
+            var property = PropertyHelper
+                .GetProperties(typeof(MyProperties))
+                .Single(p => p.Name == nameof(MyProperties.StringProp));
+
+            var accessor = PropertyHelper.MakeNullSafeFastPropertyGetter(property.Property);
+
+            // Act
+            var value = accessor(new MyProperties() { StringProp = "Hi" });
+
+            // Assert
+            Assert.Equal("Hi", value);
+        }
+
+        [Fact]
+        public void MakeNullSafeFastPropertyGetter_ReferenceType_ForNullObject_ReturnsNull()
+        {
+            // Arrange
+            var property = PropertyHelper
+                .GetProperties(typeof(BaseClass))
+                .Single(p => p.Name == nameof(BaseClass.PropA));
+
+            var accessor = PropertyHelper.MakeNullSafeFastPropertyGetter(property.Property);
+
+            // Act
+            var value = accessor(null);
+
+            // Assert
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void MakeNullSafeFastPropertyGetter_ValueType_ForNullObject_ReturnsNull()
+        {
+            // Arrange
+            var property = PropertyHelper
+                .GetProperties(typeof(MyProperties))
+                .Single(p => p.Name == nameof(MyProperties.StringProp));
+
+            var accessor = PropertyHelper.MakeNullSafeFastPropertyGetter(property.Property);
+
+            // Act
+            var value = accessor(null);
+
+            // Assert
+            Assert.Null(value);
         }
 
         private class Static

--- a/test/Microsoft.Framework.Internal.Test/PropertyHelperTest.cs
+++ b/test/Microsoft.Framework.Internal.Test/PropertyHelperTest.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.AspNet.Testing;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.Framework.Internal
@@ -190,7 +190,8 @@ namespace Microsoft.Framework.Internal
             Assert.Equal("Foo", property.Name);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void PropertyHelper_WorksForStruct()
         {
             // Arrange
@@ -271,7 +272,6 @@ namespace Microsoft.Framework.Internal
         {
             // Arrange
             var type = typeof(DerivedClassWithNonReadableProperties);
-
 
             // Act
             var result = PropertyHelper.GetProperties(type).ToArray();
@@ -430,7 +430,8 @@ namespace Microsoft.Framework.Internal
             Assert.Equal("Hi", value);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void MakeNullSafeFastPropertyGetter_ValueType_Success()
         {
             // Arrange


### PR DESCRIPTION
We need to use this in model-metadata/view-data evaluation. Though there's
generally a 'catch' in force around these expressions we can prevent
throwing in a few cases. This will also simplify some code in
ModelExplorer where we manually 'wrap' the property getter to add
null-safety.