### PR TITLE
Design: More efficient usage pattern for CopyOnWrite dictionary

### DIFF
--- a/src/Microsoft.Extensions.CopyOnWriteDictionary.Sources/CopyOnWriteDictionaryHolder.cs
+++ b/src/Microsoft.Extensions.CopyOnWriteDictionary.Sources/CopyOnWriteDictionaryHolder.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal struct CopyOnWriteDictionaryHolder<TKey, TValue>
+    {
+        private readonly Dictionary<TKey, TValue> _source;
+        private Dictionary<TKey, TValue> _copy;
+
+        public CopyOnWriteDictionaryHolder(Dictionary<TKey, TValue> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            _source = source;
+            _copy = null;
+        }
+
+        public CopyOnWriteDictionaryHolder(CopyOnWriteDictionaryHolder<TKey, TValue> source)
+        {
+            _source = source._copy ?? source._source;
+            _copy = null;
+        }
+
+        public bool HasBeenCopied => _copy != null;
+
+        public Dictionary<TKey, TValue> ReadDictionary
+        {
+            get
+            {
+                if (_copy != null)
+                {
+                    return _copy;
+                }
+                else if (_source != null)
+                {
+                    return _source;
+                }
+                else
+                {
+                    // Default-Constructor case
+                    _copy = new Dictionary<TKey, TValue>();
+                    return _copy;
+                }
+            }
+        }
+
+        public Dictionary<TKey, TValue> WriteDictionary
+        {
+            get
+            {
+                if (_copy == null && _source == null)
+                {
+                    // Default-Constructor case
+                    _copy = new Dictionary<TKey, TValue>();
+                }
+                else if (_copy == null)
+                {
+                    _copy = new Dictionary<TKey, TValue>(_source, _source.Comparer);
+                }
+
+                return _copy;
+            }
+        }
+
+        public Dictionary<TKey, TValue>.KeyCollection Keys
+        {
+            get
+            {
+                return ReadDictionary.Keys;
+            }
+        }
+
+        public Dictionary<TKey, TValue>.ValueCollection Values
+        {
+            get
+            {
+                return ReadDictionary.Values;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return ReadDictionary.Count;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                return ReadDictionary[key];
+            }
+            set
+            {
+                WriteDictionary[key] = value;
+            }
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return ReadDictionary.ContainsKey(key);
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            WriteDictionary.Add(key, value);
+        }
+
+        public bool Remove(TKey key)
+        {
+            return WriteDictionary.Remove(key);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return ReadDictionary.TryGetValue(key, out value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((ICollection<KeyValuePair<TKey, TValue>>)WriteDictionary).Add(item);
+        }
+
+        public void Clear()
+        {
+            WriteDictionary.Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>)ReadDictionary).Contains(item);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((ICollection<KeyValuePair<TKey, TValue>>)ReadDictionary).CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>)WriteDictionary).Remove(item);
+        }
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+        {
+            return ReadDictionary.GetEnumerator();
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Internal.Test/CopyOnWriteDictionaryHolderTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/CopyOnWriteDictionaryHolderTest.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+#if !DNXCORE50
+using Moq;
+#endif
+using Xunit;
+
+namespace Microsoft.Extensions.Internal
+{
+    public class CopyOnWriteDictionaryHolderTest
+    {
+#if !DNXCORE50
+        [Fact]
+        public void ReadOperation_DelegatesToSourceDictionary_IfNoMutationsArePerformed()
+        {
+            // Arrange
+            var source = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "test-key", "test-value" },
+                { "key2", "key2-value" }
+            };
+
+            var holder = new CopyOnWriteDictionaryHolder<string, object>(source);
+
+            // Act and Assert
+            Assert.Equal("key2-value", holder["key2"]);
+            Assert.Equal(2, holder.Count);
+            Assert.Equal(new string[] { "test-key", "key2" }, holder.Keys.ToArray());
+            Assert.Equal(new object[] { "test-value", "key2-value" }, holder.Values.ToArray());
+            Assert.True(holder.ContainsKey("test-key"));
+
+            object value;
+            Assert.False(holder.TryGetValue("different-key", out value));
+
+            Assert.False(holder.HasBeenCopied);
+            Assert.Same(source, holder.ReadDictionary);
+        }
+#endif
+
+        [Fact]
+        public void ReadOperation_DoesNotDelegateToSourceDictionary_OnceAValueIsChanged()
+        {
+            // Arrange
+            var source = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+
+            var holder = new CopyOnWriteDictionaryHolder<string, object>(source);
+
+            // Act
+            holder["key2"] = "value3";
+
+            // Assert
+            Assert.Equal("value2", source["key2"]);
+            Assert.Equal(2, holder.Count);
+            Assert.Equal("value1", holder["key1"]);
+            Assert.Equal("value3", holder["key2"]);
+
+            Assert.True(holder.HasBeenCopied);
+            Assert.NotSame(source, holder.ReadDictionary);
+        }
+
+        [Fact]
+        public void ReadOperation_DoesNotDelegateToSourceDictionary_OnceValueIsAdded()
+        {
+            // Arrange
+            var source = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+
+            var holder = new CopyOnWriteDictionaryHolder<string, object>(source);
+
+            // Act
+            holder.Add("key3", "value3");
+            holder.Remove("key1");
+
+            // Assert
+            Assert.Equal(2, source.Count);
+            Assert.Equal("value1", source["key1"]);
+            Assert.Equal(2, holder.Count);
+            Assert.Equal("value2", holder["KeY2"]);
+            Assert.Equal("value3", holder["key3"]);
+
+            Assert.True(holder.HasBeenCopied);
+            Assert.NotSame(source, holder.ReadDictionary);
+        }
+    }
+}


### PR DESCRIPTION
This change incorporates the key principle of the "copy-on-write" pattern into a set of building blocks that are more readily digestible based on the performance need and willingness to endure syntactic salt.

If this is deemed useful, I'll give the same treatment to my copy on write list implementation and move it over.

**I want to implement copy-on-write semantics inside my custom dictionary type**
----------------------
The pattern for this is to include `CopyOnWriteDictionaryHolder` as a member of your class. This gives you strongly typed access to the dictionary type in use (not `IDictionary<>`) which avoids boxing in some key performance scenarios. See `ModelStateDictionary` in MVC for a canonical example.

In your implementation, you can safely forward calls to the 'holder' and do optimizations to avoid boxing where it's needed for your scenario. With any custom dictionary type, it's strongly recommended to implement custom enumerator types, this change lets you do so without boxing.

This used to cost you an object allocation and 4 fields (1 in your class, 3 in the CoW class). It now costs you no allocations and 2 or 3 fields depending on your backing store. It seems like a safe assumption that we can cache the 'factory' as our comparers general vary based on the dictionary's purpose, not based on user input.