### PR TITLE
Allow non-boxing equality for StringValues

### DIFF
--- a/src/Microsoft.Extensions.Primitives/StringValues.cs
+++ b/src/Microsoft.Extensions.Primitives/StringValues.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.Primitives
 {
     /// <summary>
     /// Represents zero/null, one, or many strings in an efficient way.
     /// </summary>
-    public struct StringValues : IList<string>, IReadOnlyList<string>
+    public struct StringValues : IList<string>, IReadOnlyList<string>, IEquatable<StringValues>, IEquatable<string>, IEquatable<string[]>
     {
         private static readonly string[] EmptyArray = new string[0];
         public static readonly StringValues Empty = new StringValues(EmptyArray);
@@ -251,6 +252,170 @@ namespace Microsoft.Extensions.Primitives
             values1.CopyTo(combined, 0);
             values2.CopyTo(combined, count1);
             return new StringValues(combined);
+        }
+
+        public static bool Equals(StringValues left, StringValues right)
+        {
+            var count = left.Count;
+
+            if (count != right.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < count; i++)
+            {
+                if (left[i] != right[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool operator ==(StringValues left, StringValues right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(StringValues left, StringValues right)
+        {
+            return !Equals(left, right);
+        }
+
+        public bool Equals(StringValues other)
+        {
+            return Equals(this, other);
+        }
+
+        public static bool Equals(string left, StringValues right)
+        {
+            return Equals(new StringValues(left), right);
+        }
+
+        public static bool Equals(StringValues left, string right)
+        {
+            return Equals(left, new StringValues(right));
+        }
+
+        public bool Equals(string other)
+        {
+            return Equals(this, new StringValues(other));
+        }
+
+        public static bool Equals(string[] left, StringValues right)
+        {
+            return Equals(new StringValues(left), right);
+        }
+
+        public static bool Equals(StringValues left, string[] right)
+        {
+            return Equals(left, new StringValues(right));
+        }
+
+        public bool Equals(string[] other)
+        {
+            return Equals(this, new StringValues(other));
+        }
+
+        public static bool operator ==(StringValues left, string right)
+        {
+            return Equals(left, new StringValues(right));
+        }
+
+        public static bool operator !=(StringValues left, string right)
+        {
+            return !Equals(left, new StringValues(right));
+        }
+
+        public static bool operator ==(string left, StringValues right)
+        {
+            return Equals(new StringValues(left), right);
+        }
+
+        public static bool operator !=(string left, StringValues right)
+        {
+            return !Equals(new StringValues(left), right);
+        }
+
+        public static bool operator ==(StringValues left, string[] right)
+        {
+            return Equals(left, new StringValues(right));
+        }
+
+        public static bool operator !=(StringValues left, string[] right)
+        {
+            return !Equals(left, new StringValues(right));
+        }
+
+        public static bool operator ==(string[] left, StringValues right)
+        {
+            return Equals(new StringValues(left), right);
+        }
+
+        public static bool operator !=(string[] left, StringValues right)
+        {
+            return !Equals(new StringValues(left), right);
+        }
+
+        public static bool operator ==(StringValues left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(StringValues left, object right)
+        {
+            return !left.Equals(right);
+        }
+        public static bool operator ==(object left, StringValues right)
+        {
+            return right.Equals(left);
+        }
+
+        public static bool operator !=(object left, StringValues right)
+        {
+            return !right.Equals(left);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return Equals(this, StringValues.Empty);
+            }
+
+            if (obj is string)
+            {
+                return Equals(this, (string)obj);
+            }
+            
+            if (obj is string[])
+            {
+                return Equals(this, (string[])obj);
+            }
+
+            if (obj is StringValues)
+            {
+                return Equals(this, (StringValues)obj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            if (_values == null)
+            {
+                return _value == null ? 0 : _value.GetHashCode();
+            }
+
+            var hcc = new HashCodeCombiner();
+            for (var i = 0; i < _values.Length; i++)
+            {
+                hcc.Add(_values[i]);
+            }
+            return hcc.CombinedHash;
         }
 
         public struct Enumerator : IEnumerator<string>

--- a/test/Microsoft.Extensions.Primitives.Tests/StringValuesTests.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/StringValuesTests.cs
@@ -65,8 +65,27 @@ namespace Microsoft.Extensions.Primitives
                 {
                     { default(StringValues), (string)null },
                     { StringValues.Empty, (string)null },
+                    { new StringValues(new string[] { }), (string)null },
                     { new StringValues(string.Empty), string.Empty },
+                    { new StringValues(new string[] { string.Empty }), string.Empty },
                     { new StringValues("abc"), "abc" }
+                };
+            }
+        }
+        
+        public static TheoryData<StringValues, object> FilledStringValuesWithExpectedObjects
+        {
+            get
+            {
+                return new TheoryData<StringValues, object>
+                {
+                    { default(StringValues), (object)null },
+                    { StringValues.Empty, (object)null },
+                    { new StringValues(new string[] { }), (object)null },
+                    { new StringValues("abc"), (object)"abc" },
+                    { new StringValues("abc"), (object)new[] { "abc" } },
+                    { new StringValues(new[] { "abc" }), (object)new[] { "abc" } },
+                    { new StringValues(new[] { "abc", "bcd" }), (object)new[] { "abc", "bcd" } }
                 };
             }
         }
@@ -335,41 +354,65 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        public void Equals_Operators()
+        public void Equals_OperatorEqual()
         {
             var equalString = "abc";
+
             var equalStringArray = new string[] { equalString };
             var equalStringValues = new StringValues(equalString);
-
-            var notEqualString = "bcd";
-            var notEqualStringArray = new string[] { notEqualString };
-            var notEqualStringValues = new StringValues(notEqualString);
-
-            var stringArray = new string[] { "abc", "bcd" };
+            var stringArray = new string[] { equalString, equalString };
             var stringValuesArray = new StringValues(stringArray);
 
             Assert.True(equalStringValues == equalStringValues);
+
             Assert.True(equalStringValues == equalString);
             Assert.True(equalString == equalStringValues);
+
             Assert.True(equalStringValues == equalStringArray);
             Assert.True(equalStringArray == equalStringValues);
 
+            Assert.True(stringArray == stringValuesArray);
+            Assert.True(stringValuesArray == stringArray);
+
+            Assert.False(stringValuesArray == equalString);
+            Assert.False(stringValuesArray == equalStringArray);
+            Assert.False(stringValuesArray == equalStringValues);
+        }
+
+        [Fact]
+        public void Equals_OperatorNotEqual()
+        {
+            var equalString = "abc";
+
+            var equalStringArray = new string[] { equalString };
+            var equalStringValues = new StringValues(equalString);
+            var stringArray = new string[] { equalString, equalString };
+            var stringValuesArray = new StringValues(stringArray);
+
             Assert.False(equalStringValues != equalStringValues);
-            Assert.True(equalStringValues != notEqualStringValues);
-            Assert.True(equalStringValues != notEqualString);
-            Assert.True(notEqualString != equalStringValues);
-            Assert.True(equalStringValues != notEqualStringArray);
-            Assert.True(notEqualStringArray != equalStringValues);
+
+            Assert.False(equalStringValues != equalString);
+            Assert.False(equalString != equalStringValues);
+
+            Assert.False(equalStringValues != equalStringArray);
+            Assert.False(equalStringArray != equalStringValues);
+
+            Assert.False(stringArray != stringValuesArray);
+            Assert.False(stringValuesArray != stringArray);
+
+            Assert.True(stringValuesArray != equalString);
+            Assert.True(stringValuesArray != equalStringArray);
+            Assert.True(stringValuesArray != equalStringValues);
         }
 
         [Fact]
         public void Equals_Instance()
         {
             var equalString = "abc";
-            var equalStringArray = new string[] { "abc" };
-            var equalStringValues = new StringValues(equalString);
 
-            var stringArray = new string[] { "abc", "bcd" };
+            var equalStringArray = new string[] { equalString };
+            var equalStringValues = new StringValues(equalString);
+            var stringArray = new string[] { equalString, equalString };
             var stringValuesArray = new StringValues(stringArray);
 
             Assert.True(equalStringValues.Equals(equalStringValues));
@@ -378,32 +421,20 @@ namespace Microsoft.Extensions.Primitives
             Assert.True(stringValuesArray.Equals(stringArray));
         }
 
-        [Fact]
-        public void Equals_Object()
+        [Theory]
+        [MemberData(nameof(FilledStringValuesWithExpectedObjects))]
+        public void Equals_ObjectEquals(StringValues stringValues, object obj)
         {
-            var nullStringValues = default(StringValues);
+            Assert.True(stringValues == obj);
+            Assert.True(obj == stringValues);
+        }
 
-            var equalString = "abc";
-            var equalStringArray = new string[] { "abc" };
-            var equalStringValues = new StringValues(equalString);
-
-            var stringArray = new string[] { "abc", "bcd" };
-            var stringValuesArray = new StringValues(stringArray);
-            
-            Assert.True(nullStringValues == (object)null);
-            Assert.True((object)null == nullStringValues);
-
-            Assert.True(equalStringValues == (object)equalStringValues);
-            Assert.True((object)equalStringValues == equalStringValues);
-
-            Assert.True(equalStringValues == (object)equalString);
-            Assert.True((object)equalString == equalStringValues);
-
-            Assert.True(equalStringValues == (object)equalStringArray);
-            Assert.True((object)equalStringArray == equalStringValues);
-
-            Assert.True(stringValuesArray == (object)stringArray);
-            Assert.True((object)stringArray == stringValuesArray);
+        [Theory]
+        [MemberData(nameof(FilledStringValuesWithExpectedObjects))]
+        public void Equals_ObjectNotEquals(StringValues stringValues, object obj)
+        {
+            Assert.False(stringValues != obj);
+            Assert.False(obj != stringValues);
         }
 
         [Theory]


### PR DESCRIPTION
Currently testing for equality with StringValues will box; this allows a non boxing path.

What is equal may be up for debate? 

Also see https://github.com/aspnet/HttpAbstractions/issues/384

No idea what ```Object.Equals``` is thinks currently equal though.