### PR TITLE
Quick fix: Correct doc comments so a `xml-docs-test` target can be added in HttpAbstractions

### DIFF
--- a/src/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs
+++ b/src/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Internal
         /// </summary>
         /// <param name="provider">The service provider used to resolve dependencies</param>
         /// <param name="instanceType">The type to activate</param>
-        /// <param name="parameters">Constructor arguments not provided by the <see cref="provider"/></param>
+        /// <param name="parameters">Constructor arguments not provided by the <paramref name="provider"/></param>
         /// <returns>An activated object of type instanceType</returns>
         internal static object CreateInstance(IServiceProvider provider, Type instanceType, params object[] parameters)
         {
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Internal
         /// </summary>
         /// <typeparam name="T">The type to activate</typeparam>
         /// <param name="provider">The service provider used to resolve dependencies</param>
-        /// <param name="parameters">Constructor arguments not provided by the <see cref="provider"/></param>
+        /// <param name="parameters">Constructor arguments not provided by the <paramref name="provider"/></param>
         /// <returns>An activated object of type T</returns>
         public static T CreateInstance<T>(IServiceProvider provider, params object[] parameters)
         {


### PR DESCRIPTION
- local `xml-docs-test` target does not catch this because generated `.xml` files have no members