### PR TITLE
Add object overload to GetTypeDisplayName

### DIFF
--- a/src/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/src/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Extensions.Internal
             { typeof(ushort), "ushort" }
             };
 
+        public static string GetTypeDisplayName(object item, bool fullName = true)
+        {
+            return item == null ? null : GetTypeDisplayName(item.GetType(), fullName);
+        }
+
         public static string GetTypeDisplayName(Type type, bool fullName = true)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
This allows for upstream code to not have to handle null checking.