### PR TITLE
Partial fix for aspnet/Mvc#3676

### DIFF
--- a/src/Microsoft.Extensions.ClosedGenericMatcher.Sources/ClosedGenericMatcher.cs
+++ b/src/Microsoft.Extensions.ClosedGenericMatcher.Sources/ClosedGenericMatcher.cs
@@ -40,16 +40,63 @@ namespace Microsoft.Extensions.Internal
                 throw new ArgumentNullException(nameof(interfaceType));
             }
 
-            Func<Type, bool> matchesInterface =
-                type => type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == interfaceType;
-            if (matchesInterface(queryType))
+            // Checked type matches (i.e. is a closed generic type created from) the open generic type.
+            if (IsGenericInstantiation(queryType, interfaceType))
             {
-                // Checked type matches (i.e. is a closed generic type created from) the open generic type.
+
                 return queryType;
             }
 
             // Otherwise check all interfaces the type implements for a match.
-            return queryType.GetTypeInfo().ImplementedInterfaces.FirstOrDefault(matchesInterface);
+            // 
+            // We do this by recursing down to the most derived type, and then looking at the implemented
+            // interfaces on the way back out.
+            // - If multiple different generic instantiations exists, we want the most derived one.
+            // - If that doesn't break the tie, then we sort alphabetically so that it's deterministic.
+            return GetGenericInstantiation(queryType, interfaceType);
+        }
+
+        private static bool IsGenericInstantiation(Type candidate, Type interfaceType)
+        {
+            return
+                candidate.GetTypeInfo().IsGenericType &&
+                candidate.GetGenericTypeDefinition() == interfaceType;
+        }
+
+        private static Type GetGenericInstantiation(Type queryType, Type interfaceType)
+        {
+            // BaseType will be null for object and interfaces, which means we've reached 'bottom'.
+            var baseType = queryType?.GetTypeInfo().BaseType;
+
+            Type baseTypeMatch = null;
+            if (baseType != null)
+            {
+                baseTypeMatch = GetGenericInstantiation(baseType, interfaceType);
+            }
+
+            Type bestMatch = null;
+            var interfaces = queryType.GetInterfaces();
+            foreach (var @interface in interfaces)
+            {
+                if (IsGenericInstantiation(@interface, interfaceType))
+                {
+                    if (bestMatch == null)
+                    {
+                        bestMatch = @interface;
+                    }
+                    else if (StringComparer.Ordinal.Compare(@interface.FullName, bestMatch.FullName) < 0)
+                    {
+                        bestMatch = @interface;
+                    }
+                    else
+                    {
+                        // There are two matches at this level of the class hierarchy, but @interface is after
+                        // bestMatch in the sort order.
+                    }
+                }
+            }
+
+            return bestMatch ?? baseTypeMatch;
         }
     }
 }

--- a/src/Microsoft.Extensions.ClosedGenericMatcher.Sources/ClosedGenericMatcher.cs
+++ b/src/Microsoft.Extensions.ClosedGenericMatcher.Sources/ClosedGenericMatcher.cs
@@ -65,15 +65,6 @@ namespace Microsoft.Extensions.Internal
 
         private static Type GetGenericInstantiation(Type queryType, Type interfaceType)
         {
-            // BaseType will be null for object and interfaces, which means we've reached 'bottom'.
-            var baseType = queryType?.GetTypeInfo().BaseType;
-
-            Type baseTypeMatch = null;
-            if (baseType != null)
-            {
-                baseTypeMatch = GetGenericInstantiation(baseType, interfaceType);
-            }
-
             Type bestMatch = null;
             var interfaces = queryType.GetInterfaces();
             foreach (var @interface in interfaces)
@@ -96,7 +87,21 @@ namespace Microsoft.Extensions.Internal
                 }
             }
 
-            return bestMatch ?? baseTypeMatch;
+            if (bestMatch != null)
+            {
+                return bestMatch;
+            }
+
+            // BaseType will be null for object and interfaces, which means we've reached 'bottom'.
+            var baseType = queryType?.GetTypeInfo().BaseType;
+            if (baseType == null)
+            {
+                return null;
+            }
+            else
+            {
+                return GetGenericInstantiation(baseType, interfaceType);
+            }
         }
     }
 }

--- a/test/Microsoft.Extensions.Internal.Test/ClosedGenericMatcherTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ClosedGenericMatcherTest.cs
@@ -220,9 +220,9 @@ namespace Microsoft.Extensions.Internal
             }
         }
 
-        private class TwoIEnumerableImplementationsInherited : List<string>, IEnumerable<int>
+        private class TwoIEnumerableImplementationsInherited : List<int>, IEnumerable<string>
         {
-            IEnumerator<int> IEnumerable<int>.GetEnumerator()
+            IEnumerator<string> IEnumerable<string>.GetEnumerator()
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.Extensions.Internal.Test/ClosedGenericMatcherTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ClosedGenericMatcherTest.cs
@@ -174,6 +174,65 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal(expectedResult, result);
         }
 
+        // IEnumerable<int> is preferred because it is defined on the more-derived type.
+        [Fact]
+        public void ExtractGenericInterface_MultipleDefinitionsInherited()
+        {
+            // Arrange
+            var type = typeof(TwoIEnumerableImplementationsInherited);
+
+            // Act
+            var result = ClosedGenericMatcher.ExtractGenericInterface(type, typeof(IEnumerable<>));
+
+            // Sort
+            Assert.Equal(typeof(IEnumerable<int>), result);
+        }
+
+        // IEnumerable<int> is preferred because we sort by Ordinal on the full name.
+        [Fact]
+        public void ExtractGenericInterface_MultipleDefinitionsOnSameType()
+        {
+            // Arrange
+            var type = typeof(TwoIEnumerableImplementationsOnSameClass);
+
+            // Act
+            var result = ClosedGenericMatcher.ExtractGenericInterface(type, typeof(IEnumerable<>));
+
+            // Sort
+            Assert.Equal(typeof(IEnumerable<int>), result); 
+        }
+
+        private class TwoIEnumerableImplementationsOnSameClass : IEnumerable<string>, IEnumerable<int>
+        {
+            IEnumerator<int> IEnumerable<int>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TwoIEnumerableImplementationsInherited : List<string>, IEnumerable<int>
+        {
+            IEnumerator<int> IEnumerable<int>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         private class BaseClass : IDictionary<string, object>, IEquatable<BaseClass>
         {
             object IDictionary<string, object>.this[string key]


### PR DESCRIPTION
This change makes ClosedGenericMatcher deterministic when multiple
different generic instantiations of the same generic interface are
present.

This resolves an issue where JObject was seen to implement either
`IEnumerable<JToken>` or `IEnumerable<KeyValuePair<string, JToken>>`
depending on the order returned by reflection.

Our disambiguation rules:
- Prefer the interface declared on the more derived type
- Do a sort when a type declares two interfaces

This still isn't a totally sensible scenario for model binding (where we
hit this bug), but it should at least behave consistently now.