### PR TITLE
Add DotnetToolDispatcher.

### DIFF
--- a/Common.sln
+++ b/Common.sln
@@ -40,6 +40,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Proces
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Primitives.VSRC1", "src\Microsoft.Extensions.Primitives.VSRC1\Microsoft.Extensions.Primitives.VSRC1.xproj", "{E732FBBC-BFB3-4A3F-B20A-79BE09954F9F}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.DotnetToolDispatcher.Sources", "src\Microsoft.Extensions.DotnetToolDispatcher.Sources\Microsoft.Extensions.DotnetToolDispatcher.Sources.xproj", "{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +116,10 @@ Global
 		{E732FBBC-BFB3-4A3F-B20A-79BE09954F9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E732FBBC-BFB3-4A3F-B20A-79BE09954F9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E732FBBC-BFB3-4A3F-B20A-79BE09954F9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,5 +142,6 @@ Global
 		{C46A8C00-CD50-4478-8639-6A6CF8CDD05B} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{6DDC4681-0D48-41F6-91EB-C47381F92FF1} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{E732FBBC-BFB3-4A3F-B20A-79BE09954F9F} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 	EndGlobalSection
 EndGlobal

--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -20,6 +20,7 @@
             "Microsoft.Extensions.ActivatorUtilities.Sources": { },
             "Microsoft.Extensions.ClosedGenericMatcher.Sources": { },
             "Microsoft.Extensions.CopyOnWriteDictionary.Sources": { },
+            "Microsoft.Extensions.DotnetToolDispatcher.Sources": { },
             "Microsoft.Extensions.HashCodeCombiner.Sources": { },
             "Microsoft.Extensions.PropertyActivator.Sources": { },
             "Microsoft.Extensions.PropertyHelper.Sources": { },

--- a/src/Microsoft.Extensions.DotnetToolDispatcher.Sources/DotnetToolDispatcher.cs
+++ b/src/Microsoft.Extensions.DotnetToolDispatcher.Sources/DotnetToolDispatcher.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.PlatformAbstractions;
+using NuGet.Frameworks;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal static class DotnetToolDispatcher
+    {
+        private const string DispatcherVersionArgumentName = "--dispatcher-version";
+
+        private static readonly string DefaultToolName = PlatformServices.Default.Application.ApplicationName;
+
+        public static ICommand CreateDispatchCommand(
+            IEnumerable<string> dispatchArgs,
+            NuGetFramework framework,
+            string configuration,
+            string outputPath,
+            string buildBasePath,
+            string projectDirectory) =>
+                CreateDispatchCommand(
+                    dispatchArgs,
+                    framework,
+                    configuration,
+                    outputPath,
+                    buildBasePath,
+                    projectDirectory,
+                    DefaultToolName);
+
+        public static ICommand CreateDispatchCommand(
+            IEnumerable<string> dispatchArgs,
+            NuGetFramework framework,
+            string configuration,
+            string outputPath,
+            string buildBasePath,
+            string projectDirectory,
+            string toolName)
+        {
+            if (buildBasePath != null && !Path.IsPathRooted(buildBasePath))
+            {
+                // ProjectDependenciesCommandFactory cannot handle relative build base paths.
+                buildBasePath = Path.Combine(Directory.GetCurrentDirectory(), buildBasePath);
+            }
+
+            configuration = configuration ?? Constants.DefaultConfiguration;
+            var commandFactory = new ProjectDependenciesCommandFactory(
+                framework,
+                configuration,
+                outputPath,
+                buildBasePath,
+                projectDirectory);
+
+            var dispatcherVersionArgumentValue = ResolveDispatcherVersionArgumentValue(toolName);
+            var dispatchArgsList = new List<string>(dispatchArgs);
+            dispatchArgsList.Add(DispatcherVersionArgumentName);
+            dispatchArgsList.Add(dispatcherVersionArgumentValue);
+
+            var command = commandFactory.Create(toolName, dispatchArgsList, framework, configuration);
+            return command;
+        }
+
+        public static bool IsDispatcher(string[] programArgs) =>
+            !programArgs.Contains(DispatcherVersionArgumentName, StringComparer.OrdinalIgnoreCase);
+
+        public static void EnsureValidDispatchRecipient(ref string[] programArgs) =>
+            EnsureValidDispatchRecipient(ref programArgs, DefaultToolName);
+
+        public static void EnsureValidDispatchRecipient(ref string[] programArgs, string toolName)
+        {
+            if (!programArgs.Contains(DispatcherVersionArgumentName, StringComparer.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var dispatcherArgumentIndex = Array.FindIndex(
+                programArgs,
+                (value) => string.Equals(value, DispatcherVersionArgumentName, StringComparison.OrdinalIgnoreCase));
+            var dispatcherArgumentValueIndex = dispatcherArgumentIndex + 1;
+            if (dispatcherArgumentValueIndex < programArgs.Length)
+            {
+                var dispatcherVersion = programArgs[dispatcherArgumentValueIndex];
+
+                var dispatcherVersionArgumentValue = ResolveDispatcherVersionArgumentValue(toolName);
+                if (string.Equals(dispatcherVersion, dispatcherVersionArgumentValue, StringComparison.Ordinal))
+                {
+                    // Remove dispatcher arguments from
+                    var preDispatcherArgument = programArgs.Take(dispatcherArgumentIndex);
+                    var postDispatcherArgument = programArgs.Skip(dispatcherArgumentIndex + 2);
+                    var newProgramArguments = preDispatcherArgument.Concat(postDispatcherArgument);
+                    programArgs = newProgramArguments.ToArray();
+                    return;
+                }
+            }
+
+            // Could not validate the dispatchers version.
+            throw new InvalidOperationException(
+                $"Could not invoke tool {toolName}. Ensure it has matching versions in the project.json's 'dependencies' and 'tools' sections.");
+        }
+
+        // Internal for testing
+        internal static string ResolveDispatcherVersionArgumentValue(string toolName)
+        {
+            var toolAssembly = Assembly.Load(new AssemblyName(toolName));
+
+            var informationalVersionAttribute = toolAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+            Debug.Assert(informationalVersionAttribute != null);
+
+            var informationalVersion = informationalVersionAttribute?.InformationalVersion ??
+                toolAssembly.GetName().Version.ToString();
+
+            return informationalVersion;
+            }
+    }
+}

--- a/src/Microsoft.Extensions.DotnetToolDispatcher.Sources/Microsoft.Extensions.DotnetToolDispatcher.Sources.xproj
+++ b/src/Microsoft.Extensions.DotnetToolDispatcher.Sources/Microsoft.Extensions.DotnetToolDispatcher.Sources.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25123" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25123</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d9a0a539-4a22-4151-90b2-1d6aa4cd493d</ProjectGuid>
+    <RootNamespace>Microsoft.Extensions.DotnetToolDispatcher.Sources</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Extensions.DotnetToolDispatcher.Sources/project.json
+++ b/src/Microsoft.Extensions.DotnetToolDispatcher.Sources/project.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0-*",
+  "shared": "*.cs",
+  "dependencies": {
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*"
+  },
+  "frameworks": {
+    "net451": { },
+    "netstandard1.5": {
+      "imports": [ "portable-net451+win8+dnxcore50" ]
+    }
+  }
+}

--- a/test/Microsoft.Extensions.Internal.Test/DotnetToolDispatcherTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/DotnetToolDispatcherTest.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.DotNet.Cli.Utils;
+using Xunit;
+
+namespace Microsoft.Extensions.Internal
+{
+    public class DotnetToolDispatcherTest
+    {
+        private static readonly string TestToolName = typeof(ProjectDependenciesCommandFactory).GetTypeInfo().Assembly.GetName().Name;
+
+        public static TheoryData IsDispatcherData
+        {
+            get
+            {
+                return new TheoryData<string[], bool>
+                {
+                    { new[] { "--dispatcher-version" }, false },
+                    { new[] { "--dispatcher-Version", "1.0.0.0" }, false },
+                    { new[] { "resolve-data", "./project.json", "random", "--Dispatcher-version" }, false },
+                    { new[] { "resolve-data", "./project.json", "random", "--dispatcher-version", "1.0.0.0" }, false },
+                    { new[] { "resolve-data", "./project.json", "random" }, true },
+                    { new string[0], true },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IsDispatcherData))]
+        public void IsDispatcher_WorksAsExpected(string[] programArgs, bool expectedResult)
+        {
+            // Act
+            var isDispatcher = DotnetToolDispatcher.IsDispatcher(programArgs);
+
+            // Assert
+            Assert.Equal(expectedResult, isDispatcher);
+        }
+
+        public static TheoryData EnsureValidDispatchRecipientThrowsData
+        {
+            get
+            {
+                return new TheoryData<string[]>
+                {
+                    new[] { "--dispatcher-version" },
+                    new[] { "--dispatcher-Version", "0.1.2.3" },
+                    new[] { "resolve-data", "./project.json", "random", "--Dispatcher-version" },
+                    new[] { "resolve-data", "./project.json", "random", "--dispatcher-version", "1.0.0.0-123" },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EnsureValidDispatchRecipientThrowsData))]
+        public void EnsureValidDispatchRecipient_ThrowsWhenDispatcherVersionIsInvalid(string[] programArgs)
+        {
+            // Arrange
+            var expectedToolName = typeof(ProjectDependenciesCommandFactory).GetTypeInfo().Assembly.GetName().Name;
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => DotnetToolDispatcher.EnsureValidDispatchRecipient(ref programArgs, TestToolName));
+            Assert.Equal(
+                $"Could not invoke tool {expectedToolName}. Ensure it has matching versions in the project.json's 'dependencies' and 'tools' sections.",
+                exception.Message);
+        }
+
+        public static TheoryData EnsureValidDispatchRecipientNoopData
+        {
+            get
+            {
+                var expectedDispatcherVersion = DotnetToolDispatcher.ResolveDispatcherVersionArgumentValue(TestToolName);
+
+                return new TheoryData<string[]>
+                {
+                    new[] { "--dispatcher-Version", expectedDispatcherVersion },
+                    new[] { "resolve-data", "--dispatcher-Version", expectedDispatcherVersion, "-flag" },
+                    new[] { "resolve-data", "./project.json", "random", "--dispatcher-version", expectedDispatcherVersion },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EnsureValidDispatchRecipientNoopData))]
+        public void EnsureValidDispatchRecipient_NoopsWhenDispatcherVersionIsValid(string[] programArgs)
+        {
+            // Act & Assert (does not throw)
+            DotnetToolDispatcher.EnsureValidDispatchRecipient(ref programArgs, TestToolName);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Internal.Test/project.json
+++ b/test/Microsoft.Extensions.Internal.Test/project.json
@@ -13,6 +13,10 @@
       "type": "build",
       "version": "1.0.0-*"
     },
+    "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "type": "build",
       "version": "1.0.0-*"
@@ -33,6 +37,7 @@
       "type": "build",
       "version": "1.0.0-*"
     },
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "xunit": "2.1.0"
   },
   "testRunner": "xunit",


### PR DESCRIPTION
- This is used to unify dispatching related logic among all tools that need to exist both in the tool and dependency nodes. Currently this list consists of ef, scaffolding and Razor tooling.
- Dispatching related logic consists of: indicating if a running application is meant to be the dispatcher, validating that a dispatch recipient has compatible bits to the original dispatcher and finally invoking an inside-man in a users application.
- Add tests to validate the majority of the tool dispatcher. Did not test the dispatch command creation logic due to the requirement to build a valid project, grab its informational assembly version and communicate back and forth to ensure correctness. Lastly, this functionality will be indirectly tested by functional tests for tools consuming it.

aspnet/Coherence-Signed#276

/cc @natemcmaster @prafullbhosale