### PR TITLE
Remove x-compile to netcore50

### DIFF
--- a/src/Microsoft.Extensions.Primitives/project.json
+++ b/src/Microsoft.Extensions.Primitives/project.json
@@ -27,20 +27,6 @@
         "System.Runtime": "4.1.0-*",
         "System.Resources.ResourceManager": "4.0.1-*"
       }
-    },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": {
-          "type": "build",
-          "version": "1.0.1-*"
-        },
-        "System.Runtime": "4.0.20",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Threading": {
-          "type": "build",
-          "version": "4.0.10"
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
NB: I will repeat the removal of this tfm across all aspnet repos. 

With the latest CoreFX, this separate tfm is no longer necessary. 

cc @ericstj Microsoft.NetCore.UniversalWindowsPlatform 5.2.0-* will ship with CoreFX RTM, right?

See also:
https://github.com/aspnet/DependencyInjection/compare/namc/no-netcore50
https://github.com/aspnet/Caching/compare/namc/no-netcore50
https://github.com/aspnet/PlatformAbstractions/compare/namc/no-netcore50
https://github.com/aspnet/Microsoft.Data.Sqlite/compare/namc/no-netcore50
https://github.com/aspnet/Logging/compare/namc/no-netcore50
https://github.com/aspnet/Options/compare/namc/no-netcore50
https://github.com/aspnet/EntityFramework/pull/5398