### PR TITLE
Add TrimStart() and TrimEnd() to StringSegment

### DIFF
--- a/src/Microsoft.Extensions.Primitives/StringSegment.cs
+++ b/src/Microsoft.Extensions.Primitives/StringSegment.cs
@@ -357,6 +357,15 @@ namespace Microsoft.Extensions.Primitives
         /// <returns>The trimmed <see cref="StringSegment"/>.</returns>
         public StringSegment Trim()
         {
+            return TrimStart().TrimEnd();
+        }
+
+        /// <summary>
+        /// Removes all leading whitespaces.
+        /// </summary>
+        /// <returns>The trimmed <see cref="StringSegment"/>.</returns>
+        public StringSegment TrimStart()
+        {
             var trimmedStart = Offset;
             while (trimmedStart < Offset + Length)
             {
@@ -368,8 +377,17 @@ namespace Microsoft.Extensions.Primitives
                 trimmedStart++;
             }
 
+            return new StringSegment(Buffer, trimmedStart, Offset + Length - trimmedStart);
+        }
+
+        /// <summary>
+        /// Removes all trailing whitespaces.
+        /// </summary>
+        /// <returns>The trimmed <see cref="StringSegment"/>.</returns>
+        public StringSegment TrimEnd()
+        {
             var trimmedEnd = Offset + Length - 1;
-            while (trimmedEnd >= trimmedStart)
+            while (trimmedEnd >= Offset)
             {
                 if (!char.IsWhiteSpace(Buffer, trimmedEnd))
                 {
@@ -379,7 +397,7 @@ namespace Microsoft.Extensions.Primitives
                 trimmedEnd--;
             }
 
-            return new StringSegment(Buffer, trimmedStart, trimmedEnd - trimmedStart + 1);
+            return new StringSegment(Buffer, Offset, trimmedEnd - Offset + 1);
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.Primitives.Tests/StringSegmentTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/StringSegmentTest.cs
@@ -460,6 +460,8 @@ namespace Microsoft.Extensions.Primitives
         [InlineData("      ", 1, 2, "")]
         [InlineData("\t\t\t", 0, 3, "")]
         [InlineData("\n\n\t\t  \t", 2, 3, "")]
+        [InlineData("      ", 1, 0, "")]
+        [InlineData("", 0, 0, "")]
         public void Trim_RemovesLeadingAndTrailingWhitespaces(string value, int start, int length, string expected)
         {
             // Arrange
@@ -472,5 +474,58 @@ namespace Microsoft.Extensions.Primitives
             Assert.Equal(expected, actual.Value);
         }
 
+        [Theory]
+        [InlineData("   value", 0, 8, "value")]
+        [InlineData("value   ", 0, 8, "value   ")]
+        [InlineData("\t\tvalue", 0, 7, "value")]
+        [InlineData("value\t\t", 0, 7, "value\t\t")]
+        [InlineData("\t\tvalue \t a", 1, 8, "value \t")]
+        [InlineData("   a     ", 0, 9, "a     ")]
+        [InlineData("value\t value  value ", 2, 13, "lue\t value  v")]
+        [InlineData("\x0009value \x0085", 0, 8, "value \x0085")]
+        [InlineData(" \f\t\u000B\u2028Hello \u2029\n\t ", 1, 13, "Hello \u2029\n\t")]
+        [InlineData("      ", 1, 2, "")]
+        [InlineData("\t\t\t", 0, 3, "")]
+        [InlineData("\n\n\t\t  \t", 2, 3, "")]
+        [InlineData("      ", 1, 0, "")]
+        [InlineData("", 0, 0, "")]
+        public void TrimStart_RemovesLeadingWhitespaces(string value, int start, int length, string expected)
+        {
+            // Arrange
+            var segment = new StringSegment(value, start, length);
+
+            // Act
+            var actual = segment.TrimStart();
+
+            // Assert
+            Assert.Equal(expected, actual.Value);
+        }
+
+        [Theory]
+        [InlineData("   value", 0, 8, "   value")]
+        [InlineData("value   ", 0, 8, "value")]
+        [InlineData("\t\tvalue", 0, 7, "\t\tvalue")]
+        [InlineData("value\t\t", 0, 7, "value")]
+        [InlineData("\t\tvalue \t a", 1, 8, "\tvalue")]
+        [InlineData("   a     ", 0, 9, "   a")]
+        [InlineData("value\t value  value ", 2, 13, "lue\t value  v")]
+        [InlineData("\x0009value \x0085", 0, 8, "\x0009value")]
+        [InlineData(" \f\t\u000B\u2028Hello \u2029\n\t ", 1, 13, "\f\t\u000B\u2028Hello")]
+        [InlineData("      ", 1, 2, "")]
+        [InlineData("\t\t\t", 0, 3, "")]
+        [InlineData("\n\n\t\t  \t", 2, 3, "")]
+        [InlineData("      ", 1, 0, "")]
+        [InlineData("", 0, 0, "")]
+        public void TrimEnd_RemovesTrailingWhitespaces(string value, int start, int length, string expected)
+        {
+            // Arrange
+            var segment = new StringSegment(value, start, length);
+
+            // Act
+            var actual = segment.TrimEnd();
+
+            // Assert
+            Assert.Equal(expected, actual.Value);
+        }
     }
 }


### PR DESCRIPTION
We should add this since `TrimStart()` and `TrimEnd()` are available on `string` but are currently missing on `StringSegment`. @Tratcher 