### PR TITLE
Added stack trace helper 

### DIFF
--- a/Common.sln
+++ b/Common.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FEAA3936-5906-4383-B750-F07FE1B156C5}"
 EndProject
@@ -39,6 +39,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Process.Sources", "src\Microsoft.Extensions.Process.Sources\Microsoft.Extensions.Process.Sources.xproj", "{6DDC4681-0D48-41F6-91EB-C47381F92FF1}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.DotnetToolDispatcher.Sources", "src\Microsoft.Extensions.DotnetToolDispatcher.Sources\Microsoft.Extensions.DotnetToolDispatcher.Sources.xproj", "{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.StackTrace.Sources", "src\Microsoft.Extensions.StackTrace.Sources\Microsoft.Extensions.StackTrace.Sources.xproj", "{B245CE2A-F918-4116-9D5C-4C21527D0AC5}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ClassLibraryWithPortablePdbs", "test\ClassLibraryWithPortablePdbs\ClassLibraryWithPortablePdbs.xproj", "{A2ABDB54-1E32-4BEE-81A1-C0353802A0C0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -114,6 +118,14 @@ Global
 		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B245CE2A-F918-4116-9D5C-4C21527D0AC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B245CE2A-F918-4116-9D5C-4C21527D0AC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B245CE2A-F918-4116-9D5C-4C21527D0AC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B245CE2A-F918-4116-9D5C-4C21527D0AC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2ABDB54-1E32-4BEE-81A1-C0353802A0C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2ABDB54-1E32-4BEE-81A1-C0353802A0C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2ABDB54-1E32-4BEE-81A1-C0353802A0C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2ABDB54-1E32-4BEE-81A1-C0353802A0C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,5 +148,7 @@ Global
 		{C46A8C00-CD50-4478-8639-6A6CF8CDD05B} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{6DDC4681-0D48-41F6-91EB-C47381F92FF1} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{D9A0A539-4A22-4151-90B2-1D6AA4CD493D} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{B245CE2A-F918-4116-9D5C-4C21527D0AC5} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
+		{A2ABDB54-1E32-4BEE-81A1-C0353802A0C0} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Extensions.StackTrace.Sources/Microsoft.Extensions.StackTrace.Sources.xproj
+++ b/src/Microsoft.Extensions.StackTrace.Sources/Microsoft.Extensions.StackTrace.Sources.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b245ce2a-f918-4116-9d5c-4c21527d0ac5</ProjectGuid>
+    <RootNamespace>Microsoft.Extensions.StackTrace.Sources</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Extensions.StackTrace.Sources/PortablePdbReader.cs
+++ b/src/Microsoft.Extensions.StackTrace.Sources/PortablePdbReader.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.Extensions.StackTrace.Sources
+{
+    internal class PortablePdbReader : IDisposable
+    {
+        private readonly Dictionary<string, MetadataReaderProvider> _cache =
+            new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
+
+        public void PopulateStackFrame(StackFrameInfo frameInfo, MethodBase method, int IlOffset)
+        {
+            var metadataReader = GetMetadataReader(method.Module.Assembly.Location);
+
+            if (metadataReader == null)
+            {
+                return;
+            }
+
+            var methodToken = MetadataTokens.Handle(method.MetadataToken);
+
+            Debug.Assert(methodToken.Kind == HandleKind.MethodDefinition);
+
+            var handle = ((MethodDefinitionHandle)methodToken).ToDebugInformationHandle();
+
+            if (!handle.IsNil)
+            {
+                var methodDebugInfo = metadataReader.GetMethodDebugInformation(handle);
+                var sequencePoints = methodDebugInfo.GetSequencePoints();
+                SequencePoint? bestPointSoFar = null;
+
+                foreach (var point in sequencePoints)
+                {
+                    if (point.Offset > IlOffset)
+                    {
+                        break;
+                    }
+
+                    if (point.StartLine != SequencePoint.HiddenLine)
+                    {
+                        bestPointSoFar = point;
+                    }
+                }
+
+                if (bestPointSoFar.HasValue)
+                {
+                    frameInfo.LineNumber = bestPointSoFar.Value.StartLine;
+                    frameInfo.FilePath = metadataReader.GetString(metadataReader.GetDocument(bestPointSoFar.Value.Document).Name);
+                }
+            }
+        }
+
+        private MetadataReader GetMetadataReader(string assemblyPath)
+        {
+            MetadataReaderProvider provider = null;
+            if (!_cache.TryGetValue(assemblyPath, out provider))
+            {
+                var pdbPath = GetPdbPath(assemblyPath);
+
+                if (!string.IsNullOrEmpty(pdbPath) && File.Exists(pdbPath))
+                {
+                    var pdbStream = File.OpenRead(pdbPath);
+                    provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+                }
+
+                _cache[assemblyPath] = provider;
+            }
+
+            return provider?.GetMetadataReader();
+        }
+
+        private static string GetPdbPath(string assemblyPath)
+        {
+            if (string.IsNullOrEmpty(assemblyPath))
+            {
+                return null;
+            }
+
+            if (File.Exists(assemblyPath))
+            {
+                var peStream = File.OpenRead(assemblyPath);
+
+                using (var peReader = new PEReader(peStream))
+                {
+                    foreach (var entry in peReader.ReadDebugDirectory())
+                    {
+                        if (entry.Type == DebugDirectoryEntryType.CodeView)
+                        {
+                            var codeViewData = peReader.ReadCodeViewDebugDirectoryData(entry);
+                            var peDirectory = Path.GetDirectoryName(assemblyPath);
+                            return Path.Combine(peDirectory, Path.GetFileName(codeViewData.Path));
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public void Dispose()
+        {
+            foreach (var entry in _cache)
+            {
+                entry.Value?.Dispose();
+            }
+
+            _cache.Clear();
+        }
+    }
+}

--- a/src/Microsoft.Extensions.StackTrace.Sources/StackFrameInfo.cs
+++ b/src/Microsoft.Extensions.StackTrace.Sources/StackFrameInfo.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Extensions.StackTrace.Sources
+{
+    internal class StackFrameInfo
+    {
+        public int LineNumber { get; set; }
+
+        public string FilePath { get; set; }
+
+        public string Method { get; set; }
+
+        public StackFrame StackFrame { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.StackTrace.Sources/StackTraceHelper.cs
+++ b/src/Microsoft.Extensions.StackTrace.Sources/StackTraceHelper.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.StackTrace.Sources
+{
+    internal class StackTraceHelper
+    {
+        public static IList<StackFrameInfo> GetFrames(Exception exception)
+        {
+            var frames = new List<StackFrameInfo>();
+
+            if (exception == null)
+            {
+                return frames;
+            }
+
+            using (var portablePdbReader = new PortablePdbReader())
+            {
+                var needFileInfo = true;
+                var stackTrace = new System.Diagnostics.StackTrace(exception, needFileInfo);
+                var stackFrames = stackTrace.GetFrames();
+
+                if (stackFrames == null)
+                {
+                    return frames;
+                }
+
+                foreach (var frame in stackFrames)
+                {
+                    var method = frame.GetMethod();
+
+                    var stackFrame = new StackFrameInfo
+                    {
+                        StackFrame = frame,
+                        FilePath = frame.GetFileName(),
+                        LineNumber = frame.GetFileLineNumber(),
+                        Method = method.Name,
+                    };
+
+#if NET451
+                    if (string.IsNullOrEmpty(stackFrame.FilePath))
+                    {
+                        // .NET Framework and older versions of mono don't support portable PDBs
+                        // so we read it manually to get file name and line information
+                        portablePdbReader.PopulateStackFrame(stackFrame, method, frame.GetILOffset());
+                    }
+#endif
+
+                    frames.Add(stackFrame);
+
+                }
+
+                return frames;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.StackTrace.Sources/project.json
+++ b/src/Microsoft.Extensions.StackTrace.Sources/project.json
@@ -1,0 +1,8 @@
+﻿{
+  "version": "1.0.0-*",
+  "shared": "*.cs",
+  "frameworks": {
+    "net451": { },
+    "netstandard1.3": { }
+  }
+}

--- a/test/ClassLibraryWithPortablePdbs/ClassLibraryWithPortablePdbs.xproj
+++ b/test/ClassLibraryWithPortablePdbs/ClassLibraryWithPortablePdbs.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a2abdb54-1e32-4bee-81a1-c0353802a0c0</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/ClassLibraryWithPortablePdbs/ExceptionType.cs
+++ b/test/ClassLibraryWithPortablePdbs/ExceptionType.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace ClassLibraryWithPortablePdbs
+{
+    public class ExceptionType
+    {
+        public static void StaticMethodThatThrows()
+        {
+            throw new Exception();
+        }
+
+        public void MethodThatThrows()
+        {
+            throw new Exception();
+        }
+
+        public void CallMethodThatThrows()
+        {
+            MethodThatThrows();
+        }
+    }
+}

--- a/test/ClassLibraryWithPortablePdbs/project.json
+++ b/test/ClassLibraryWithPortablePdbs/project.json
@@ -1,0 +1,12 @@
+﻿{
+  "version": "1.0.0",
+  "buildOptions": {
+    "debugType": "portable" 
+  },
+  "dependencies": {
+    "System.Runtime": "4.1.0-*"
+  },
+  "frameworks": {
+    "netstandard1.0": { }
+  }
+}

--- a/test/Microsoft.Extensions.Internal.Test/StackTraceTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/StackTraceTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using ClassLibraryWithPortablePdbs;
+using Microsoft.Extensions.StackTrace.Sources;
+using Xunit;
+
+namespace Microsoft.Extensions.Internal.Test
+{
+    public class StackTraceTest
+    {
+        public static TheoryData CanGetStackTraceData => new TheoryData<Action, string>
+        {
+            { ThrowsException, nameof(ThrowsException) },
+            { CallsThrowsException, nameof(ThrowsException) },
+            { new ExceptionType().MethodThatThrows, nameof(ExceptionType.MethodThatThrows) },
+            { new ExceptionType().CallMethodThatThrows, nameof(ExceptionType.MethodThatThrows) },
+            { ExceptionType.StaticMethodThatThrows, nameof(ExceptionType.StaticMethodThatThrows) }
+        };
+
+        [Theory]
+        [MemberData(nameof(CanGetStackTraceData))]
+        public void GetFrames_CanGetStackTrace(Action action, string expectedMethodName)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception exception)
+            {
+                // Arrange and Act
+                var frames = StackTraceHelper.GetFrames(exception);
+
+                // Assert
+                Assert.Equal(expectedMethodName, frames.First().Method);
+                Assert.Equal(nameof(GetFrames_CanGetStackTrace), frames.Last().Method);
+            }
+        }
+
+        public static void ThrowsException()
+        {
+            throw new Exception();
+        }
+
+        public static void CallsThrowsException()
+        {
+            ThrowsException();
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Internal.Test/project.json
+++ b/test/Microsoft.Extensions.Internal.Test/project.json
@@ -1,8 +1,10 @@
 {
   "buildOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "debugType": "full"
   },
   "dependencies": {
+    "ClassLibraryWithPortablePdbs": "1.0.0",
     "dotnet-test-xunit": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.AspNetCore.Testing": "1.0.0-*",
@@ -38,6 +40,10 @@
       "type": "build",
       "version": "1.0.0-*"
     },
+    "Microsoft.Extensions.StackTrace.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "xunit": "2.1.0"
   },
@@ -54,7 +60,9 @@
           "type": "platform"
         },
         "System.Diagnostics.Process": "4.1.0-*",
+        "System.Diagnostics.StackTrace": "4.0.1-*",
         "System.Diagnostics.TraceSource": "4.0.0-*",
+        "System.Reflection.Metadata": "1.3.0-*",
         "moq.netcore": "4.4.0-beta8"
       }
     },


### PR DESCRIPTION
- Added a method to get the stack trace as an object model for various
scenarios. These will be used for the ASP.NET error pages in the Hosting
and Diagnostics repositories
- ~~Works around bugs on older mono where portable pdbs aren't supported~~

/cc @pranavkm 