### PR TITLE
Command line utils: allow 'inherited' options

### DIFF
--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandOption.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandOption.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Extensions.CommandLineUtils
         public List<string> Values { get; private set; }
         public CommandOptionType OptionType { get; private set; }
 
+        public bool Inherited { get; set; }
+
         public bool TryParse(string value)
         {
             switch (OptionType)

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
+using System.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 using Xunit;
 
@@ -363,7 +363,7 @@ namespace Microsoft.Extensions.Internal
 
             app.Command("k", c =>
             {
-                subCmd = c.Command("run", _=> { });
+                subCmd = c.Command("run", _ => { });
                 c.OnExecute(() => 0);
             });
 
@@ -389,6 +389,117 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal(0, testCmd.RemainingArguments.Count);
             Assert.Equal(1, subCmd.RemainingArguments.Count);
             Assert.Equal(unexpectedOption, subCmd.RemainingArguments[0]);
+        }
+
+        [Fact]
+        public void OptionsCanBeInherited()
+        {
+            var app = new CommandLineApplication();
+            var optionA = app.Option("-a|--option-a", "", CommandOptionType.SingleValue, inherited: true);
+            string optionAValue = null;
+
+            var optionB = app.Option("-b", "", CommandOptionType.SingleValue, inherited: false);
+
+            var subcmd = app.Command("subcmd", c =>
+            {
+                c.OnExecute(() =>
+                {
+                    optionAValue = optionA.Value();
+                    return 0;
+                });
+            });
+
+            Assert.Equal(2, app.GetOptions().Count());
+            Assert.Equal(1, subcmd.GetOptions().Count());
+
+            app.Execute("-a", "A1", "subcmd");
+            Assert.Equal("A1", optionAValue);
+
+            Assert.Throws<CommandParsingException>(() => app.Execute("subcmd", "-b", "B"));
+
+            Assert.Contains("-a|--option-a", subcmd.GetHelpText());
+        }
+
+        [Fact]
+        public void NestedOptionConflictThrows()
+        {
+            var app = new CommandLineApplication();
+            app.Option("-a|--always", "Top-level", CommandOptionType.SingleValue, inherited: true);
+            app.Command("subcmd", c =>
+            {
+                c.Option("-a|--ask", "Nested", CommandOptionType.SingleValue);
+            });
+
+            Assert.Throws<InvalidOperationException>(() => app.Execute("subcmd", "-a", "b"));
+        }
+
+        [Fact]
+        public void OptionsWithSameName()
+        {
+            var app = new CommandLineApplication();
+            var top = app.Option("-a|--always", "Top-level", CommandOptionType.SingleValue, inherited: false);
+            CommandOption nested = null;
+            app.Command("subcmd", c =>
+            {
+                nested = c.Option("-a|--ask", "Nested", CommandOptionType.SingleValue);
+            });
+
+            app.Execute("-a", "top");
+            Assert.Equal("top", top.Value());
+            Assert.Null(nested.Value());
+            
+            top.Values.Clear();
+
+            app.Execute("subcmd", "-a", "nested");
+            Assert.Null(top.Value());
+            Assert.Equal("nested", nested.Value());
+        }
+
+
+        [Fact]
+        public void NestedInheritedOptions()
+        {
+            string globalOptionValue = null, nest1OptionValue = null, nest2OptionValue = null;
+
+            var app = new CommandLineApplication();
+            CommandLineApplication subcmd2 = null;
+            var g = app.Option("-g|--global", "Global option", CommandOptionType.SingleValue, inherited: true);
+            var subcmd1 = app.Command("lvl1", s1 =>
+            {
+                var n1 = s1.Option("--nest1", "Nested one level down", CommandOptionType.SingleValue, inherited: true);
+                subcmd2 = s1.Command("lvl2", s2 =>
+                {
+                    var n2 = s2.Option("--nest2", "Nested one level down", CommandOptionType.SingleValue, inherited: true);
+                    s2.HelpOption("-h|--help");
+                    s2.OnExecute(() =>
+                    {
+                        globalOptionValue = g.Value();
+                        nest1OptionValue = n1.Value();
+                        nest2OptionValue = n2.Value();
+                        return 0;
+                    });
+                });
+            });
+
+            Assert.False(app.GetOptions().Any(o => o.LongName == "nest2"));
+            Assert.False(app.GetOptions().Any(o => o.LongName == "nest1"));
+            Assert.Contains(app.GetOptions(), o => o.LongName == "global");
+
+            Assert.False(subcmd1.GetOptions().Any(o => o.LongName == "nest2"));
+            Assert.Contains(subcmd1.GetOptions(), o => o.LongName == "nest1");
+            Assert.Contains(subcmd1.GetOptions(), o => o.LongName == "global");
+
+            Assert.Contains(subcmd2.GetOptions(), o => o.LongName == "nest2");
+            Assert.Contains(subcmd2.GetOptions(), o => o.LongName == "nest1");
+            Assert.Contains(subcmd2.GetOptions(), o => o.LongName == "global");
+
+            Assert.Throws<CommandParsingException>(() => app.Execute("--nest2", "N2", "--nest1", "N1", "-g", "G"));
+            Assert.Throws<CommandParsingException>(() => app.Execute("lvl1", "--nest2", "N2", "--nest1", "N1", "-g", "G"));
+
+            app.Execute("lvl1", "lvl2", "--nest2", "N2", "-g", "G", "--nest1", "N1");
+            Assert.Equal("G", globalOptionValue);
+            Assert.Equal("N1", nest1OptionValue);
+            Assert.Equal("N2", nest2OptionValue);
         }
     }
 }


### PR DESCRIPTION
Some options apply to all subcommands. This makes improves usability so that inherited commands can be specified in any order