### PR TITLE
Allow parameters to be hidden from help text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ nuget.exe
 *.sln.ide
 node_modules
 **/[Cc]ompiler/[Rr]esources/**/*.js
+.vscode/

--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandArgument.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandArgument.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         }
 
         public string Name { get; set; }
+        public bool Hidden { get; set; }
         public string Description { get; set; }
         public List<string> Values { get; private set; }
         public bool MultipleValues { get; set; }

--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandArgument.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandArgument.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         }
 
         public string Name { get; set; }
-        public bool Hidden { get; set; }
+        public bool ShowInHelpText { get; set; } = true;
         public string Description { get; set; }
         public List<string> Values { get; private set; }
         public bool MultipleValues { get; set; }

--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         public string FullName { get; set; }
         public string Syntax { get; set; }
         public string Description { get; set; }
-        public bool Hidden { get; set; }
+        public bool ShowInHelpText { get; set; } = true;
         public readonly List<CommandOption> Options;
         public CommandOption OptionHelp { get; private set; }
         public CommandOption OptionVersion { get; private set; }
@@ -376,7 +376,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             var commandsBuilder = new StringBuilder();
             var argumentsBuilder = new StringBuilder();
 
-            var arguments = target.Arguments.Where(a => !a.Hidden).ToList();
+            var arguments = target.Arguments.Where(a => a.ShowInHelpText).ToList();
             if (arguments.Any())
             {
                 headerBuilder.Append(" [arguments]");
@@ -392,7 +392,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                 }
             }
 
-            var options = target.GetOptions().Where(o => !o.Hidden).ToList();
+            var options = target.GetOptions().Where(o => o.ShowInHelpText).ToList();
             if (options.Any())
             {
                 headerBuilder.Append(" [options]");
@@ -408,7 +408,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                 }
             }
 
-            var commands = target.Commands.Where(c => !c.Hidden).ToList();
+            var commands = target.Commands.Where(c => c.ShowInHelpText).ToList();
             if (commands.Any())
             {
                 headerBuilder.Append(" [command]");

--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         public string FullName { get; set; }
         public string Syntax { get; set; }
         public string Description { get; set; }
+        public bool Hidden { get; set; }
         public readonly List<CommandOption> Options;
         public CommandOption OptionHelp { get; private set; }
         public CommandOption OptionVersion { get; private set; }
@@ -341,7 +342,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             Console.WriteLine(GetHelpText(commandName));
         }
 
-        public string GetHelpText(string commandName = null)
+        public virtual string GetHelpText(string commandName = null)
         {
             var headerBuilder = new StringBuilder("Usage:");
             for (var cmd = this; cmd != null; cmd = cmd.Parent)
@@ -375,22 +376,23 @@ namespace Microsoft.Extensions.CommandLineUtils
             var commandsBuilder = new StringBuilder();
             var argumentsBuilder = new StringBuilder();
 
-            if (target.Arguments.Any())
+            var arguments = target.Arguments.Where(a => !a.Hidden).ToList();
+            if (arguments.Any())
             {
                 headerBuilder.Append(" [arguments]");
 
                 argumentsBuilder.AppendLine();
                 argumentsBuilder.AppendLine("Arguments:");
-                var maxArgLen = target.Arguments.Max(a => a.Name.Length);
+                var maxArgLen = arguments.Max(a => a.Name.Length);
                 var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxArgLen + 2);
-                foreach (var arg in target.Arguments)
+                foreach (var arg in arguments)
                 {
                     argumentsBuilder.AppendFormat(outputFormat, arg.Name, arg.Description);
                     argumentsBuilder.AppendLine();
                 }
             }
 
-            var options = target.GetOptions().ToList();
+            var options = target.GetOptions().Where(o => !o.Hidden).ToList();
             if (options.Any())
             {
                 headerBuilder.Append(" [options]");
@@ -406,15 +408,16 @@ namespace Microsoft.Extensions.CommandLineUtils
                 }
             }
 
-            if (target.Commands.Any())
+            var commands = target.Commands.Where(c => !c.Hidden).ToList();
+            if (commands.Any())
             {
                 headerBuilder.Append(" [command]");
 
                 commandsBuilder.AppendLine();
                 commandsBuilder.AppendLine("Commands:");
-                var maxCmdLen = target.Commands.Max(c => c.Name.Length);
+                var maxCmdLen = commands.Max(c => c.Name.Length);
                 var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxCmdLen + 2);
-                foreach (var cmd in target.Commands.OrderBy(c => c.Name))
+                foreach (var cmd in commands.OrderBy(c => c.Name))
                 {
                     commandsBuilder.AppendFormat(outputFormat, cmd.Name, cmd.Description);
                     commandsBuilder.AppendLine();
@@ -423,7 +426,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                 if (OptionHelp != null)
                 {
                     commandsBuilder.AppendLine();
-                    commandsBuilder.AppendFormat("Use \"{0} [command] --help\" for more information about a command.", Name);
+                    commandsBuilder.AppendFormat($"Use \"{target.Name} [command] --{OptionHelp.LongName}\" for more information about a command.");
                     commandsBuilder.AppendLine();
                 }
             }

--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandOption.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandOption.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         public string Description { get; set; }
         public List<string> Values { get; private set; }
         public CommandOptionType OptionType { get; private set; }
-        public bool Hidden { get; set; }
+        public bool ShowInHelpText { get; set; } = true;
         public bool Inherited { get; set; }
 
         public bool TryParse(string value)

--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandOption.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandOption.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         public string Description { get; set; }
         public List<string> Values { get; private set; }
         public CommandOptionType OptionType { get; private set; }
-
+        public bool Hidden { get; set; }
         public bool Inherited { get; set; }
 
         public bool TryParse(string value)

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -514,18 +514,18 @@ namespace Microsoft.Extensions.Internal
             app.Command("star", c =>
             {
                 c.Option("--points <p>", "How many", CommandOptionType.MultipleValue);
-                c.Hidden = true;
+                c.ShowInHelpText = false;
             });
-            app.Option("--no-kill", "Be a nice ninja", CommandOptionType.NoValue, o => { o.Hidden = true; });
+            app.Option("--smile", "Be a nice ninja", CommandOptionType.NoValue, o => { o.ShowInHelpText = false; });
 
             var a = app.Argument("name", "Pseudonym, of course");
-            a.Hidden = true;
+            a.ShowInHelpText = false;
 
             var help = app.GetHelpText();
 
             Assert.Contains("ninja-app", help);
             Assert.DoesNotContain("--points", help);
-            Assert.DoesNotContain("--no-kill", help);
+            Assert.DoesNotContain("--smile", help);
             Assert.DoesNotContain("name", help);
         }
 

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Extensions.Internal
             app.Execute("-a", "top");
             Assert.Equal("top", top.Value());
             Assert.Null(nested.Value());
-            
+
             top.Values.Clear();
 
             app.Execute("subcmd", "-a", "nested");
@@ -500,6 +500,46 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal("G", globalOptionValue);
             Assert.Equal("N1", nest1OptionValue);
             Assert.Equal("N2", nest2OptionValue);
+        }
+
+        [Fact]
+        public void HelpTextIgnoresHiddenItems()
+        {
+            var app = new CommandLineApplication()
+            {
+                Name = "ninja-app",
+                Description = "You can't see it until it is too late"
+            };
+
+            app.Command("star", c =>
+            {
+                c.Option("--points <p>", "How many", CommandOptionType.MultipleValue);
+                c.Hidden = true;
+            });
+            app.Option("--no-kill", "Be a nice ninja", CommandOptionType.NoValue, o => { o.Hidden = true; });
+
+            var a = app.Argument("name", "Pseudonym, of course");
+            a.Hidden = true;
+
+            var help = app.GetHelpText();
+
+            Assert.Contains("ninja-app", help);
+            Assert.DoesNotContain("--points", help);
+            Assert.DoesNotContain("--no-kill", help);
+            Assert.DoesNotContain("name", help);
+        }
+
+        [Fact]
+        public void HelpTextUsesHelpOptionName()
+        {
+            var app = new CommandLineApplication
+            {
+                Name = "superhombre"
+            };
+
+            app.HelpOption("--ayuda-me");
+            var help = app.GetHelpText();
+            Assert.Contains("--ayuda-me", help);
         }
     }
 }


### PR DESCRIPTION
cc @NTaylorMullen so we can parse dispatcher version using the command line app but not put it the help text.