### PR TITLE
Create source packages for command line utils

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -14,6 +14,7 @@
         "packages": {
             "Microsoft.Extensions.ActivatorUtilities.Sources": { },
             "Microsoft.Extensions.ClosedGenericMatcher.Sources": { },
+            "Microsoft.Extensions.CommandLineUtils.Sources": { },
             "Microsoft.Extensions.CopyOnWriteDictionary.Sources": { },
             "Microsoft.Extensions.DotnetToolDispatcher.Sources": { },
             "Microsoft.Extensions.HashCodeCombiner.Sources": { },

--- a/src/Microsoft.Extensions.CommandLineUtils.Sources/project.json
+++ b/src/Microsoft.Extensions.CommandLineUtils.Sources/project.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.1.0-*",
+  "shared": "../Microsoft.Extensions.CommandLineUtils/CommandLine/*.cs",
+  "frameworks": {
+    "net451": {},
+    "netstandard1.3": {}
+  }
+}


### PR DESCRIPTION
We want to create "ef.exe" that can be copied w/o needing to also copy "Microsoft.Extensions.CommandLineUtils.dll" along with it.

cc @muratg @pranavkm 