### PR TITLE
Fix ChangeOnToken to ignore consumer exceptions

### DIFF
--- a/src/Microsoft.Extensions.Primitives/ChangeToken.cs
+++ b/src/Microsoft.Extensions.Primitives/ChangeToken.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Primitives
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback.
                 var t = changeTokenProducer();
-                changeTokenConsumer();
+                try { changeTokenConsumer(); } catch { } // Uncaught exceptions are really bad here
                 t.RegisterChangeCallback(callback, null);
             };
 
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Primitives
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback.
                 var t = changeTokenProducer();
-                changeTokenConsumer((TState)s);
+                try { changeTokenConsumer((TState)s); } catch { } // Uncaught exceptions are really bad here
                 t.RegisterChangeCallback(callback, s);
             };
 

--- a/src/Microsoft.Extensions.Primitives/ChangeToken.cs
+++ b/src/Microsoft.Extensions.Primitives/ChangeToken.cs
@@ -40,9 +40,10 @@ namespace Microsoft.Extensions.Primitives
                 {
                     changeTokenConsumer();
                 }
-                catch // Uncaught exceptions are really bad here
-                { }
-                t.RegisterChangeCallback(callback, null);
+                finally // We always want to ensure the callback is registered
+                {
+                    t.RegisterChangeCallback(callback, null);
+                }
             };
 
             return changeTokenProducer().RegisterChangeCallback(callback, null);
@@ -79,9 +80,10 @@ namespace Microsoft.Extensions.Primitives
                 {
                     changeTokenConsumer((TState)s);
                 }
-                catch // Uncaught exceptions are really bad here
-                { }
-                t.RegisterChangeCallback(callback, s);
+                finally // We always want to ensure the callback is registered
+                {
+                    t.RegisterChangeCallback(callback, s);
+                }
             };
 
             return changeTokenProducer().RegisterChangeCallback(callback, state);

--- a/src/Microsoft.Extensions.Primitives/ChangeToken.cs
+++ b/src/Microsoft.Extensions.Primitives/ChangeToken.cs
@@ -36,7 +36,12 @@ namespace Microsoft.Extensions.Primitives
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback.
                 var t = changeTokenProducer();
-                try { changeTokenConsumer(); } catch { } // Uncaught exceptions are really bad here
+                try
+                {
+                    changeTokenConsumer();
+                }
+                catch // Uncaught exceptions are really bad here
+                { }
                 t.RegisterChangeCallback(callback, null);
             };
 
@@ -70,7 +75,12 @@ namespace Microsoft.Extensions.Primitives
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback.
                 var t = changeTokenProducer();
-                try { changeTokenConsumer((TState)s); } catch { } // Uncaught exceptions are really bad here
+                try
+                {
+                    changeTokenConsumer((TState)s);
+                }
+                catch // Uncaught exceptions are really bad here
+                { }
                 t.RegisterChangeCallback(callback, s);
             };
 

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Extensions.Primitives
                 count++;
                 throw new Exception();
             });
-            token.Changed();
+            Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(1, count);
-            token.Changed();
+            Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(2, count);
         }
 
@@ -80,10 +80,10 @@ namespace Microsoft.Extensions.Primitives
                 count++;
                 throw new Exception();
             }, state);
-            token.Changed();
+            Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(1, count);
             Assert.NotNull(callbackState);
-            token.Changed();
+            Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(2, count);
             Assert.NotNull(callbackState);
         }

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -40,6 +40,22 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        public void ChangesFireAfterExceptions()
+        {
+            TestChangeToken token = null;
+            var count = 0;
+            ChangeToken.OnChange(() => token = new TestChangeToken(), () =>
+            {
+                count++;
+                throw new Exception();
+            });
+            token.Changed();
+            Assert.Equal(1, count);
+            token.Changed();
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
         public void HasChangeFiresChangeWithState()
         {
             var token = new TestChangeToken();
@@ -49,6 +65,27 @@ namespace Microsoft.Extensions.Primitives
             Assert.Null(callbackState);
             token.Changed();
             Assert.Equal(state, callbackState);
+        }
+
+        [Fact]
+        public void ChangesFireAfterExceptionsWithState()
+        {
+            TestChangeToken token = null;
+            var count = 0;
+            object state = new object();
+            object callbackState = null;
+            ChangeToken.OnChange(() => token = new TestChangeToken(), s =>
+            {
+                callbackState = s;
+                count++;
+                throw new Exception();
+            }, state);
+            token.Changed();
+            Assert.Equal(1, count);
+            Assert.NotNull(callbackState);
+            token.Changed();
+            Assert.Equal(2, count);
+            Assert.NotNull(callbackState);
         }
     }
 }


### PR DESCRIPTION
Part 1 of fixing configuration reload on change.

We need to continue getting invoked after an exception happens during the consumer code

cc @divega @BrennanConroy 