### PR TITLE
fix #149 by serializing reads/writes

### DIFF
--- a/Common.sln
+++ b/Common.sln
@@ -48,9 +48,9 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.RazorV
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.TaskCache.Sources", "src\Microsoft.Extensions.TaskCache.Sources\Microsoft.Extensions.TaskCache.Sources.xproj", "{E27BA960-5526-416C-BF46-2261F4C6B82C}"
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.AwaitableStream", "src\Microsoft.Extensions.AwaitableStream\Microsoft.Extensions.AwaitableStream.xproj", "{D58B7D9F-1EA9-4459-ACA1-CE934E7DF5AF}"
-EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.AwaitableStream.Test", "test\Microsoft.Extensions.AwaitableStream.Test\Microsoft.Extensions.AwaitableStream.Test.xproj", "{57D8121E-E20B-43F6-9598-B10275C55E57}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.AwaitableStream", "src\Microsoft.Extensions.AwaitableStream\Microsoft.Extensions.AwaitableStream.xproj", "{5F723AB6-4601-4A12-9FC8-5BF4BA9C9C3C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -142,14 +142,14 @@ Global
 		{E27BA960-5526-416C-BF46-2261F4C6B82C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E27BA960-5526-416C-BF46-2261F4C6B82C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E27BA960-5526-416C-BF46-2261F4C6B82C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D58B7D9F-1EA9-4459-ACA1-CE934E7DF5AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D58B7D9F-1EA9-4459-ACA1-CE934E7DF5AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D58B7D9F-1EA9-4459-ACA1-CE934E7DF5AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D58B7D9F-1EA9-4459-ACA1-CE934E7DF5AF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{57D8121E-E20B-43F6-9598-B10275C55E57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{57D8121E-E20B-43F6-9598-B10275C55E57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57D8121E-E20B-43F6-9598-B10275C55E57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57D8121E-E20B-43F6-9598-B10275C55E57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F723AB6-4601-4A12-9FC8-5BF4BA9C9C3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F723AB6-4601-4A12-9FC8-5BF4BA9C9C3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F723AB6-4601-4A12-9FC8-5BF4BA9C9C3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F723AB6-4601-4A12-9FC8-5BF4BA9C9C3C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -176,7 +176,7 @@ Global
 		{C60445B0-452F-4321-9E66-847BCB4DEEC8} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{F0749087-822C-4EDF-9091-96791D3C772E} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{E27BA960-5526-416C-BF46-2261F4C6B82C} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
-		{D58B7D9F-1EA9-4459-ACA1-CE934E7DF5AF} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{57D8121E-E20B-43F6-9598-B10275C55E57} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
+		{5F723AB6-4601-4A12-9FC8-5BF4BA9C9C3C} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Extensions.AwaitableStream/Internal/Gate.cs
+++ b/src/Microsoft.Extensions.AwaitableStream/Internal/Gate.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.AwaitableStream.Internal
+{
+    /// <summary>
+    /// Simple awaitable gate - intended to synchronize a single producer with a single consumer to ensure the producer doesn't
+    /// produce until the consumer is ready. Similar to a <see cref="TaskCompletionSource{TResult}"/> but reusable so we don't have
+    /// to keep allocating new ones every time.
+    /// </summary>
+    /// <remarks>
+    /// The gate can be in one of two states: "Open", indicating that an await will immediately return and "Closed", meaning that an await
+    /// will block until the gate is opened. The gate is initially "Closed" and can be opened by a call to <see cref="Open"/>. Upon the completion
+    /// of an await, it will automatically return to the "Closed" state (this is done in the <see cref="GetResult"/> call that is injected by the
+    /// compiler's async/await logic).
+    /// </remarks>
+    public class Gate : ICriticalNotifyCompletion
+    {
+        private static readonly Action _completed = () => {};
+
+        private volatile Action _continuation;
+
+        /// <summary>
+        /// Returns a boolean indicating if the gate is "open"
+        /// </summary>
+        public bool IsCompleted => _continuation == _completed;
+
+        public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
+
+        public void OnCompleted(Action continuation)
+        {
+            // If we're already completed, call the continuation immediately
+            if (_continuation == _completed)
+            {
+                continuation();
+            }
+            else
+            {
+                // Otherwise, if the current continuation is null, atomically store the new continuation in the field and return the old value
+                var previous = Interlocked.CompareExchange(ref _continuation, continuation, null);
+                if (previous == _completed)
+                {
+                    // It got completed in the time between the previous the method and the cmpexch.
+                    // So call the continuation (the value of _continuation will remain _completed because cmpexch is atomic,
+                    // so we didn't accidentally replace it).
+                    continuation();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resets the gate to continue blocking the waiter. This is called immediately after awaiting the signal.
+        /// </summary>
+        public void GetResult()
+        {
+            // Clear the active continuation to "reset" the state of this event
+            Interlocked.Exchange(ref _continuation, null);
+        }
+
+        /// <summary>
+        /// Set the gate to allow the waiter to continue.
+        /// </summary>
+        public void Open()
+        {
+            // Set the stored continuation value to a sentinel that indicates the state is completed, then call the previous value.
+            var completion = Interlocked.Exchange(ref _continuation, _completed);
+            completion?.Invoke();
+        }
+
+        public Gate GetAwaiter() => this;
+    }
+}

--- a/src/Microsoft.Extensions.AwaitableStream/Microsoft.Extensions.AwaitableStream.xproj
+++ b/src/Microsoft.Extensions.AwaitableStream/Microsoft.Extensions.AwaitableStream.xproj
@@ -11,7 +11,6 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Microsoft.Extensions.AwaitableStream/project.json
+++ b/src/Microsoft.Extensions.AwaitableStream/project.json
@@ -21,10 +21,12 @@
       "imports": "dnxcore50",
       "dependencies": {
         "System.Collections": "4.0.11",
+        "System.Diagnostics.Debug": "4.0.11",
         "System.IO": "4.1.0",
-        "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
-        "System.Threading": "4.0.11"
+        "System.Resources.ResourceManager": "4.0.1",
+        "System.Threading": "4.0.11",
+        "System.Threading.Tasks.Extensions": "4.0.0"
       }
     }
   }

--- a/test/Microsoft.Extensions.AwaitableStream.Test/GateTests.cs
+++ b/test/Microsoft.Extensions.AwaitableStream.Test/GateTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AwaitableStream.Internal;
+using Xunit;
+
+namespace Microsoft.Extensions.AwaitableStream.Test
+{
+    /// <summary>
+    /// Tests for the <see cref="Gate"/> type. Although it is internal, it is a critical
+    /// synchronization primitive so we want to know it works :).
+    /// </summary>
+    public class GateTests
+    {
+        [Fact]
+        public async Task ItBlocksOneTaskUntilTheGateIsReleased()
+        {
+            // Use TCS for more "traditional" synchronization that is already known to work :).
+            var initTcs = new TaskCompletionSource<object>();
+
+            // The gate we're testing
+            var gate = new Gate();
+
+            // Set up the producer thread.
+            var producer = Task.Run(async () =>
+            {
+                // We're ready, task initialization has finished, etc.
+                initTcs.SetResult(null);
+
+                // Wait for the gate to release
+                await gate;
+            });
+
+            // Wait for the produce to start
+            await initTcs.Task;
+
+            // Open the gate
+            gate.Open();
+
+            // Wait for the producer to finish, with a 200ms timeout
+            var finished = await Task.WhenAny(producer, Task.Delay(200));
+
+            // Assert.True/False are the only one that take a custom message :(
+            Assert.True(ReferenceEquals(finished, producer), "Timeout elapsed!");
+        }
+
+        [Fact]
+        public async Task ItImmediatelyClosesAfterOpening()
+        {
+            // Use TCS for more "traditional" synchronization that is already known to work :).
+            var initTcs = new TaskCompletionSource<object>();
+            var secondTcs = new TaskCompletionSource<object>();
+            var cts = new CancellationTokenSource();
+
+            // The gate we're testing
+            var gate = new Gate();
+
+            // Set up the producer thread.
+            var producer = Task.Run(async () =>
+            {
+                // We're ready, task initialization has finished, etc.
+                initTcs.SetResult(null);
+
+                // Wait for the gate to release
+                await gate;
+                Assert.False(gate.IsCompleted, "The gate did not close immediately after opening!");
+
+                // Signal that the gate has closed again
+                secondTcs.SetResult(null);
+
+                // Wait for a second release (it's never going to happen!)
+                await gate;
+            }, cts.Token);
+
+            // Wait for the produce to start
+            await initTcs.Task;
+
+            // Open the gate
+            gate.Open();
+
+            // Wait for the gate to close again
+            // (without this wait, we don't know if the gate will actually have closed again! the produce may not have run yet)
+            var finished = await Task.WhenAny(secondTcs.Task, Task.Delay(200));
+
+            // Assert.True/False are the only one that take a custom message :(
+            Assert.True(ReferenceEquals(finished, secondTcs.Task), "Timeout elapsed!");
+
+            // Open the gate
+            gate.Open();
+
+            // Wait for the producer to finish, with a 200ms timeout
+            finished = await Task.WhenAny(producer, Task.Delay(200));
+
+            // Assert.True/False are the only one that take a custom message :(
+            Assert.True(ReferenceEquals(finished, producer), "Timeout elapsed!");
+        }
+    }
+}

--- a/test/Microsoft.Extensions.AwaitableStream.Test/Microsoft.Extensions.AwaitableStream.Test.xproj
+++ b/test/Microsoft.Extensions.AwaitableStream.Test/Microsoft.Extensions.AwaitableStream.Test.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>57d8121e-e20b-43f6-9598-b10275c55e57</ProjectGuid>
@@ -13,9 +12,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
With this change, AwaitableStream.WriteAsync will not complete until the
NEXT ReadAsync call begins. This means that the writer cannot reuse the
buffer until we are sure that the receiver has finished, INCLUDING all
async callback.

There is a small risk in the receiver calling ReadAsync before actually
finishing with the buffer, but this is no different than we have in the
synchronous receiver scenario.

/cc @davidfowl @halter73 