### PR TITLE
Add InplaceStringBuilder

### DIFF
--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -40,20 +40,20 @@ namespace Microsoft.Extensions.Primitives
         public unsafe void Append(string s)
         {
             EnsureCapacity(s.Length);
-            fixed (char* value = _value)
-            fixed (char* pDomainToken = s)
+            fixed (char* destination = _value)
+            fixed (char* source = s)
             {
                 //TODO: https://github.com/aspnet/Common/issues/158
-                Unsafe.CopyBlock(value + _offset, pDomainToken, (uint)s.Length * 2);
+                Unsafe.CopyBlock(destination + _offset, source, (uint)s.Length * 2);
                 _offset += s.Length;
             }
         }
         public unsafe void Append(char c)
         {
             EnsureCapacity(1);
-            fixed (char* value = _value)
+            fixed (char* destination = _value)
             {
-                value[_offset++] = c;
+                destination[_offset++] = c;
             }
         }
 

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Primitives
         {
             if (_offset != _capacity)
             {
-                throw new InvalidOperationException($"Entire reserved length was not used. Length: '{_capacity}', written '{_offset}'.");
+                throw new InvalidOperationException($"Entire reserved capacity was not used. Capacity: '{_capacity}', written '{_offset}'.");
             }
             return _value;
         }

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Primitives
 {
+    [DebuggerDisplay("Value = {_value}")]
     public struct InplaceStringBuilder
     {
         private int _capacity;
@@ -41,7 +43,7 @@ namespace Microsoft.Extensions.Primitives
             fixed (char* value = _value)
             fixed (char* pDomainToken = s)
             {
-                //TODO: Use CopyBlockUnaligned when added https://github.com/dotnet/corefx/issues/12243
+                //TODO: https://github.com/aspnet/Common/issues/158
                 Unsafe.CopyBlock(value + _offset, pDomainToken, (uint)s.Length * 2);
                 _offset += s.Length;
             }
@@ -68,21 +70,13 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
-        // Debugger calls ToString so this method should be used to get formatted value
-        public string Build()
+        public override string ToString()
         {
             if (_offset != _capacity)
             {
                 throw new InvalidOperationException($"Entire reserved length was not used. Length: '{_capacity}', written '{_offset}'.");
             }
             return _value;
-        }
-
-        public override string ToString()
-        {
-            // Clone string so we won't be modifying returned string if called before
-            // whole value was written
-            return new string(_value.ToCharArray());
         }
     }
 }

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.Primitives
+{
+    public struct InplaceStringBuilder
+    {
+        private int _length;
+        private int _offset;
+        private bool _writing;
+        private string _value;
+
+        public InplaceStringBuilder(int length) : this()
+        {
+            _length = length;
+        }
+
+        public void AppendLength(string s)
+        {
+            AppendLength(s.Length);
+        }
+        public void AppendLength(char c)
+        {
+            AppendLength(1);
+        }
+
+        public void AppendLength(int length)
+        {
+            if (_writing)
+            {
+                throw new InvalidOperationException("Cannot append lenght after write started.");
+            }
+            _length += length;
+        }
+
+        public unsafe void Append(string s)
+        {
+            EnsureValue(s.Length);
+            fixed (char* value = _value)
+            fixed (char* pDomainToken = s)
+            {
+                Unsafe.CopyBlock(value + _offset, pDomainToken, (uint)s.Length * 2);
+                _offset += s.Length;
+            }
+        }
+        public unsafe void Append(char c)
+        {
+            EnsureValue(1);
+            fixed (char* value = _value)
+            {
+                value[_offset++] = c;
+            }
+        }
+
+        private void EnsureValue(int length)
+        {
+            if (_value == null)
+            {
+                _writing = true;
+                _value = new string('\0', _length);
+            }
+            if (_offset + length > _length)
+            {
+                throw new InvalidOperationException($"Not enough space to write '{length}' characters, only '{_length - _offset}' left.");
+            }
+        }
+
+        // Debugger calls ToString so this method should be used to get formatted value
+        public string Build()
+        {
+            if (_offset != _length)
+            {
+                throw new InvalidOperationException($"Entire reserved lenght was not used. Length: '{_length}', written '{_offset}'.");
+            }
+            return _value;
+        }
+
+        public override string ToString()
+        {
+            // Clone string so we won't be modifying returned string if called before
+            // whole value was written
+            return new string(_value.ToCharArray());
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -18,16 +18,17 @@ namespace Microsoft.Extensions.Primitives
             _length = length;
         }
 
-        public void AppendLength(string s)
+        public void IncrementLength(string s)
         {
-            AppendLength(s.Length);
-        }
-        public void AppendLength(char c)
-        {
-            AppendLength(1);
+            IncrementLength(s.Length);
         }
 
-        public void AppendLength(int length)
+        public void IncrementLength(char c)
+        {
+            IncrementLength(1);
+        }
+
+        public void IncrementLength(int length)
         {
             if (_writing)
             {

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Extensions.Primitives
             fixed (char* value = _value)
             fixed (char* pDomainToken = s)
             {
+                //TODO: Use CopyBlockUnaligned when added https://github.com/dotnet/corefx/issues/12243
                 Unsafe.CopyBlock(value + _offset, pDomainToken, (uint)s.Length * 2);
                 _offset += s.Length;
             }

--- a/src/Microsoft.Extensions.Primitives/project.json
+++ b/src/Microsoft.Extensions.Primitives/project.json
@@ -16,13 +16,15 @@
     "nowarn": [
       "CS1591"
     ],
-    "xmlDoc": true
+    "xmlDoc": true,
+    "allowUnsafe": true
   },
   "dependencies": {
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "type": "build",
       "version": "1.1.0-*"
-    }
+  },
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
     "netstandard1.0": {

--- a/src/Microsoft.Extensions.Primitives/project.json
+++ b/src/Microsoft.Extensions.Primitives/project.json
@@ -23,7 +23,7 @@
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "type": "build",
       "version": "1.1.0-*"
-  },
+    },
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {

--- a/src/Microsoft.Extensions.Primitives/project.json
+++ b/src/Microsoft.Extensions.Primitives/project.json
@@ -24,6 +24,7 @@
       "type": "build",
       "version": "1.1.0-*"
     },
+    "System.Diagnostics.Debug": "4.0.11",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -14,9 +14,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var s2 = "56789";
 
             var formatter = new InplaceStringBuilder();
-            formatter.IncrementLength(s1);
-            formatter.IncrementLength(c1);
-            formatter.IncrementLength(s2);
+            formatter.Capacity += s1.Length + 1 + s2.Length;
             formatter.Append(s1);
             formatter.Append(c1);
             formatter.Append(s2);
@@ -29,7 +27,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(5);
             formatter.Append("123");
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Build());
-            Assert.Equal(exception.Message, "Entire reserved lenght was not used. Length: '5', written '3'.");
+            Assert.Equal(exception.Message, "Entire reserved length was not used. Length: '5', written '3'.");
         }
 
         [Fact]
@@ -38,8 +36,8 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(3);
             formatter.Append("123");
 
-            var exception = Assert.Throws<InvalidOperationException>(() => formatter.IncrementLength(1));
-            Assert.Equal(exception.Message, "Cannot append lenght after write started.");
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.Capacity = 5);
+            Assert.Equal(exception.Message, "Cannot append length after write started.");
         }
 
         [Fact]
@@ -48,7 +46,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(1);
 
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Append("123"));
-            Assert.Equal(exception.Message, "Not enough space to write '3' characters, only '1' left.");
+            Assert.Equal(exception.Message, "Not enough capacity to write '3' characters, only '1' left.");
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var s2 = "56789";
 
             var formatter = new InplaceStringBuilder();
-            formatter.AppendLength(s1);
-            formatter.AppendLength(c1);
-            formatter.AppendLength(s2);
+            formatter.IncrementLength(s1);
+            formatter.IncrementLength(c1);
+            formatter.IncrementLength(s2);
             formatter.Append(s1);
             formatter.Append(c1);
             formatter.Append(s2);
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(3);
             formatter.Append("123");
 
-            var exception = Assert.Throws<InvalidOperationException>(() => formatter.AppendLength(1));
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.IncrementLength(1));
             Assert.Equal(exception.Message, "Cannot append lenght after write started.");
         }
 

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Http.Tests.Internal
+{
+    public class InplaceStringBuilderTest
+    {
+        [Fact]
+        public void ToString_ReturnsStringWithAllAppendedValues()
+        {
+            var s1 = "123";
+            var c1 = '4';
+            var s2 = "56789";
+
+            var formatter = new InplaceStringBuilder();
+            formatter.AppendLength(s1);
+            formatter.AppendLength(c1);
+            formatter.AppendLength(s2);
+            formatter.Append(s1);
+            formatter.Append(c1);
+            formatter.Append(s2);
+            Assert.Equal("123456789", formatter.Build());
+        }
+
+        [Fact]
+        public void Build_ThrowsIfNotEnoughWritten()
+        {
+            var formatter = new InplaceStringBuilder(5);
+            formatter.Append("123");
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.Build());
+            Assert.Equal(exception.Message, "Entire reserved lenght was not used. Length: '5', written '3'.");
+        }
+
+        [Fact]
+        public void AppendLength_IfAppendWasCalled()
+        {
+            var formatter = new InplaceStringBuilder(3);
+            formatter.Append("123");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.AppendLength(1));
+            Assert.Equal(exception.Message, "Cannot append lenght after write started.");
+        }
+
+        [Fact]
+        public void Append_ThrowsIfNotEnoughSpace()
+        {
+            var formatter = new InplaceStringBuilder(1);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.Append("123"));
+            Assert.Equal(exception.Message, "Not enough space to write '3' characters, only '1' left.");
+        }
+
+        [Fact]
+        public void ToString_ReturnsPartialyFormatedValue()
+        {
+            var formatter = new InplaceStringBuilder(5);
+            formatter.Append("123");
+
+            Assert.Equal("123\0\0", formatter.ToString());
+        }
+
+        [Fact]
+        public void ToString_ReturnedValueIsNotModified()
+        {
+            var formatter = new InplaceStringBuilder(5);
+            formatter.Append("123");
+
+            var s = formatter.ToString();
+            Assert.Equal("123\0\0", s);
+
+            formatter.Append("45");
+            Assert.Equal("123\0\0", s);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             formatter.Append(s1);
             formatter.Append(c1);
             formatter.Append(s2);
-            Assert.Equal("123456789", formatter.Build());
+            Assert.Equal("123456789", formatter.ToString());
         }
 
         [Fact]
@@ -26,18 +26,18 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
         {
             var formatter = new InplaceStringBuilder(5);
             formatter.Append("123");
-            var exception = Assert.Throws<InvalidOperationException>(() => formatter.Build());
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.ToString());
             Assert.Equal(exception.Message, "Entire reserved length was not used. Length: '5', written '3'.");
         }
 
         [Fact]
-        public void AppendLength_IfAppendWasCalled()
+        public void Capacity_ThrowsIfAppendWasCalled()
         {
             var formatter = new InplaceStringBuilder(3);
             formatter.Append("123");
 
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Capacity = 5);
-            Assert.Equal(exception.Message, "Cannot append length after write started.");
+            Assert.Equal(exception.Message, "Cannot change capacity after write started.");
         }
 
         [Fact]
@@ -47,28 +47,6 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
 
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Append("123"));
             Assert.Equal(exception.Message, "Not enough capacity to write '3' characters, only '1' left.");
-        }
-
-        [Fact]
-        public void ToString_ReturnsPartialyFormatedValue()
-        {
-            var formatter = new InplaceStringBuilder(5);
-            formatter.Append("123");
-
-            Assert.Equal("123\0\0", formatter.ToString());
-        }
-
-        [Fact]
-        public void ToString_ReturnedValueIsNotModified()
-        {
-            var formatter = new InplaceStringBuilder(5);
-            formatter.Append("123");
-
-            var s = formatter.ToString();
-            Assert.Equal("123\0\0", s);
-
-            formatter.Append("45");
-            Assert.Equal("123\0\0", s);
         }
     }
 }

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(5);
             formatter.Append("123");
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.ToString());
-            Assert.Equal(exception.Message, "Entire reserved length was not used. Length: '5', written '3'.");
+            Assert.Equal(exception.Message, "Entire reserved capacity was not used. Capacity: '5', written '3'.");
         }
 
         [Fact]


### PR DESCRIPTION
Migrated from: https://github.com/aspnet/HttpAbstractions/pull/717

Added `.Build()` method for better debugging experience.

Intended to be used instead of pooled StringBuilder or string.Concat when all parts of string are known. (Use cases: https://github.com/aspnet/HttpAbstractions/pull/699, https://github.com/aspnet/HttpAbstractions/pull/716)

Does only 1 allocation of resulting string.

@benaadams @davidfowl @Tratcher @halter73 @rynowak
