### PR TITLE
Make StringSegment more inlinable

### DIFF
--- a/src/Microsoft.Extensions.Primitives/StringSegment.cs
+++ b/src/Microsoft.Extensions.Primitives/StringSegment.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Primitives
 {
@@ -29,12 +30,12 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="buffer">The original <see cref="string"/> used as buffer.</param>
         /// <param name="offset">The offset of the segment within the <paramref name="buffer"/>.</param>
         /// <param name="length">The length of the segment.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public StringSegment(string buffer, int offset, int length)
         {
-            // This .ctor is specially arranged to allow it to inline
+            // This .ctor is specially arranged to allow it to be very small when inlines 50 IL bytes
             // If either offset or length is negative, then (offset | length) < 0.
-            // Testing them individually causes to many blocks for the inliner to decide its profitable
-            // Current result: Successfully inlined StringSegment:.ctor(ref, int, int):this(50 IL bytes)(depth 1)[profitable inline]
+            // Testing them individually causes too many blocks for the inliner to decide its profitable
             if (buffer == null || (offset | length) < 0 || offset > buffer.Length - length)
             {
                 ThrowInvalidArguments(buffer, offset, length);

--- a/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
+++ b/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Extensions.Primitives
+{
+    internal static class ThrowHelper
+    {
+        internal static void ThrowArgumentNullException(ExceptionArgument argument)
+        {
+            throw new ArgumentNullException(GetArgumentName(argument));
+        }
+
+        internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            throw new ArgumentOutOfRangeException(GetArgumentName(argument));
+        }
+
+        internal static void ThrowArgumentException(ExceptionResource resource)
+        {
+            throw new ArgumentException(GetResourceText(resource));
+        }
+
+        internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
+        {
+            return new ArgumentNullException(GetArgumentName(argument));
+        }
+
+        internal static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            return new ArgumentOutOfRangeException(GetArgumentName(argument));
+        }
+
+        internal static ArgumentException GetArgumentException(ExceptionResource resource)
+        {
+            return new ArgumentException(GetResourceText(resource));
+        }
+
+        private static string GetResourceText(ExceptionResource resource)
+        {
+            return Resources.ResourceManager.GetString(GetResourceName(resource), Resources.Culture);
+        }
+
+        private static string GetArgumentName(ExceptionArgument argument)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
+                "The enum value is not defined, please check the ExceptionArgument Enum.");
+
+            return argument.ToString();
+        }
+
+        private static string GetResourceName(ExceptionResource resource)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionResource), resource),
+                "The enum value is not defined, please check the ExceptionResource Enum.");
+
+            return resource.ToString();
+        }
+    }
+
+    internal enum ExceptionArgument
+    {
+        buffer,
+        offset,
+        length,
+        text,
+        start,
+        count
+    }
+
+    internal enum ExceptionResource
+    {
+        Argument_InvalidOffsetLength
+    }
+}


### PR DESCRIPTION
As noted in https://github.com/aspnet/Mvc/issues/5362 the `StringSegment:.ctor(ref,int,int):this` is not inlinable.

This change makes it inline (also avoids a 16 byte copy when calling the .ctor)

/cc @rynowak @dougbu 
