### PR TITLE
Extend help output with arbitrary content

### DIFF
--- a/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         public string Syntax { get; set; }
         public string Description { get; set; }
         public bool ShowInHelpText { get; set; } = true;
+        public string ExtendedHelpText { get; set; }
         public readonly List<CommandOption> Options;
         public CommandOption OptionHelp { get; private set; }
         public CommandOption OptionVersion { get; private set; }
@@ -457,7 +458,8 @@ namespace Microsoft.Extensions.CommandLineUtils
                 + headerBuilder.ToString()
                 + argumentsBuilder.ToString()
                 + optionsBuilder.ToString()
-                + commandsBuilder.ToString();
+                + commandsBuilder.ToString()
+                + target.ExtendedHelpText;
         }
 
         public void ShowVersion()

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -580,5 +580,23 @@ namespace Microsoft.Extensions.Internal
             app.HelpOption("-h|--help");
             Assert.Contains("Usage: proxy-command [options] [[--] <arg>...]", app.GetHelpText());
         }
+
+        [Fact]
+        public void HelpTextShowsExtendedHelp()
+        {
+            var app = new CommandLineApplication()
+            {
+                Name = "befuddle",
+                ExtendedHelpText = @"
+Remarks:
+  This command is so confusing that I want to include examples in the help text.
+
+Examples:
+  dotnet befuddle -- I Can Haz Confusion Arguments
+"
+            };
+
+            Assert.Contains(app.ExtendedHelpText, app.GetHelpText());
+        }
     }
 }


### PR DESCRIPTION
I want to add custom help to dotnet-watch. Adding API to allow users to plugin custom help text.

cc @pranavkm 