### PR TITLE
Cleanup tmp files after korebuild downloads

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ if test ! -d $buildFolder; then
     chmod +x $buildFile
     
     # Cleanup
-    if test ! -d $tempFolder; then
+    if test -d $tempFolder; then
         rm -rf $tempFolder  
     fi
 fi


### PR DESCRIPTION
This little flaw led to >10,000 tmp copies of KoreBuild being left in /tmp on our build agents.

I will apply this fix to all build.sh files in our aspnet repos.

cc @Eilon @pranavkm 