### PR TITLE
Don't implment Enumerator Dispose explicitly

### DIFF
--- a/src/Microsoft.Extensions.Primitives/StringValues.cs
+++ b/src/Microsoft.Extensions.Primitives/StringValues.cs
@@ -464,7 +464,7 @@ namespace Microsoft.Extensions.Primitives
                 throw new NotSupportedException();
             }
 
-            void IDisposable.Dispose()
+            public void Dispose()
             {
             }
         }


### PR DESCRIPTION
Make the finally block of a foreach overly complicated
```
    finally
    {
      IL_0021: ldloca.s     V_0
      IL_0023: constrained. [Microsoft.Extensions.Primitives]Microsoft.Extensions.Primitives.StringValues/Enumerator
      IL_0029: callvirt     instance void [mscorlib]System.IDisposable::Dispose()
      IL_002e: endfinally   
    } // end of finally
```
Rather than a just a straight `call`