### PR TITLE
[Suggestion] Centralize CorrelationIds

### DIFF
--- a/src/Microsoft.Extensions.Primitives/CorrelationGenerator.cs
+++ b/src/Microsoft.Extensions.Primitives/CorrelationGenerator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Extensions.Primitives
+{
+    public static class CorrelationGenerator
+    {
+        private static long _lastId = GenerateIdSeed();
+
+        public static CorrelationId GetNextId()
+        {
+            return new CorrelationId(Interlocked.Increment(ref _lastId));
+        }
+
+        private static long GenerateIdSeed()
+        {
+            // Seed the _lastId for this application instance with a roughly increasing CorrelationId over restarts
+
+            // The number of 100-nanosecond intervals that have elapsed since the release of ASP.NET Core 1.0
+            var dateTimeSeed = (DateTime.UtcNow.Ticks - new DateTime(2016, 6, 27).Ticks);
+            // Mask off max imprecision 
+            var imprecision = TimeSpan.TicksPerMillisecond * 30;
+            dateTimeSeed -= dateTimeSeed % imprecision;
+
+            unchecked
+            {
+                // Increase events per second x 100. 
+                // Decrease from 10000 years without seed wrap to 100 years without seed wrap (e.g. 2116)
+                // Means 1 billion events until next second is encountered rather than 10 million events
+                dateTimeSeed *= 100;
+            }
+            imprecision *= 100;
+            // Fill masked off imprecision with Stopwatch.GetTimestamp in case restarts happen in same 30ms period
+            dateTimeSeed += Stopwatch.GetTimestamp() % imprecision;
+
+            return dateTimeSeed;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Primitives/CorrelationId.cs
+++ b/src/Microsoft.Extensions.Primitives/CorrelationId.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.Primitives
+{
+    public struct CorrelationId : IComparable<CorrelationId>, IEquatable<CorrelationId>
+    {
+        // Base32 encoding - in ascii sort order for easy text based sorting
+        private const string _encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV";
+
+        private long _id;
+        private string _stringId;
+
+        public long Id => _id;
+
+        internal CorrelationId(long correlationId)
+        {
+            _id = correlationId;
+            _stringId = null;
+        }
+
+        public override string ToString() => _stringId ?? GenerateCorrelationString();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal unsafe string GenerateCorrelationString()
+        {
+            // The following routine is ~310% faster than calling long.ToString() on x64
+            // and ~600% faster than calling long.ToString() on x86 in tight loops of 1 million+ iterations
+            // See: https://github.com/aspnet/Hosting/pull/385
+
+            var id = _id;
+            // stackalloc to allocate array on stack rather than heap
+            char* charBuffer = stackalloc char[13];
+
+            charBuffer[0] = _encode32Chars[(int)(id >> 60) & 31];
+            charBuffer[1] = _encode32Chars[(int)(id >> 55) & 31];
+            charBuffer[2] = _encode32Chars[(int)(id >> 50) & 31];
+            charBuffer[3] = _encode32Chars[(int)(id >> 45) & 31];
+            charBuffer[4] = _encode32Chars[(int)(id >> 40) & 31];
+            charBuffer[5] = _encode32Chars[(int)(id >> 35) & 31];
+            charBuffer[6] = _encode32Chars[(int)(id >> 30) & 31];
+            charBuffer[7] = _encode32Chars[(int)(id >> 25) & 31];
+            charBuffer[8] = _encode32Chars[(int)(id >> 20) & 31];
+            charBuffer[9] = _encode32Chars[(int)(id >> 15) & 31];
+            charBuffer[10] = _encode32Chars[(int)(id >> 10) & 31];
+            charBuffer[11] = _encode32Chars[(int)(id >> 5) & 31];
+            charBuffer[12] = _encode32Chars[(int)id & 31];
+
+            // string ctor overload that takes char*
+            var s = new string(charBuffer, 0, 13);
+            _stringId = s;
+            return s;
+        }
+
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public int CompareTo(CorrelationId other) => Id.CompareTo(other.Id);
+
+        public bool Equals(CorrelationId other) => Id.Equals(other.Id);
+    }
+}


### PR DESCRIPTION
[TraceIdentifier](https://github.com/aspnet/HttpAbstractions/blob/dev/src/Microsoft.AspNetCore.Http/Features/HttpRequestIdentifierFeature.cs#L37-L62) and [ConnectionId](https://github.com/aspnet/KestrelHttpServer/blob/dev/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs#L401-L426) repeat the same logic; there is no reason why they couldn't come from the same source. Also means a request's Id will be logically greater than its connection's id; and new connection id's will be greater than older requests rather than independent.

Other change is to use more of the numeric domain. Seed the release of ASP.NET Core as min Id. Seed current start as now+timestamp; increase the number of unique events per-second from 10 million to 1 billion to reduce chance of restart clash (overkill 😛 - but might be used for additional events).

/cc @davidfowl 