### PR TITLE
Improve test coverage

### DIFF
--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -650,7 +650,7 @@ Examples:
             Assert.True(optVerbose.HasValue());
         }
 
-        [Fact(Skip = "As of version 1.1.0 giving the help option aborts processing without settig it")]
+        [Fact(Skip = "Until now giving the help option aborts processing without settig it")]
         public void HelpOptionCanBeSet()
         {
             var app = new CommandLineApplication();
@@ -661,7 +661,7 @@ Examples:
             Assert.True(optHelp.HasValue());
         }
 
-        [Fact(Skip = "As of version 1.1.0 giving the version option aborts processing without settig it")]
+        [Fact(Skip = "Until now giving the version option aborts processing without settig it")]
         public void VersionOptionCanBeSet()
         {
             var app = new CommandLineApplication();

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.CommandLineUtils;
 using Xunit;
 
@@ -455,7 +457,6 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal("nested", nested.Value());
         }
 
-
         [Fact]
         public void NestedInheritedOptions()
         {
@@ -597,6 +598,113 @@ Examples:
             };
 
             Assert.Contains(app.ExtendedHelpText, app.GetHelpText());
+        }
+
+        [Theory]
+        [InlineData(new[] { "--version", "--flag" }, "1.0")]
+        [InlineData(new[] { "-V", "-f" }, "1.0")]
+        [InlineData(new[] { "--help", "--flag" }, "some flag")]
+        [InlineData(new[] { "-h", "-f" }, "some flag")]
+        public void HelpAndVersionOptionStopProcessing(string[] input, string expectedOutData)
+        {
+            using (StringWriter outWriter = new StringWriter())
+            {
+                var app = new CommandLineApplication { Out = outWriter };
+                app.HelpOption("-h --help");
+                app.VersionOption("-V --version", "1", "1.0");
+                var optFlag = app.Option("-f |--flag", "some flag", CommandOptionType.NoValue);
+
+                app.Execute(input);
+
+                outWriter.Flush();
+                string outData = outWriter.ToString();
+                Assert.Contains(expectedOutData, outData);
+                Assert.False(optFlag.HasValue());
+            }
+        }
+
+        [Theory]
+        [InlineData("-f:File1", "-f:File2")]
+        [InlineData("--file:File1", "--file:File2")]
+        [InlineData("--file", "File1", "--file", "File2")]
+        public void ThrowsExceptionOnSingleValueOptionHavingTwoValues(params string[] inputOptions)
+        {
+            var app = new CommandLineApplication();
+            app.Option("-f |--file", "some file", CommandOptionType.SingleValue);
+
+            var exception = Assert.Throws<CommandParsingException>(() => app.Execute(inputOptions));
+
+            Assert.Equal("Unexpected value 'File2' for option 'file'", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--verbose")]
+        public void NoValueOptionCanBeSet(string input)
+        {
+            var app = new CommandLineApplication();
+            var optVerbose = app.Option("-v |--verbose", "be verbose", CommandOptionType.NoValue);
+
+            app.Execute(input);
+
+            Assert.True(optVerbose.HasValue());
+        }
+
+        [Fact(Skip = "As of version 1.1.0 giving the help option aborts processing without settig it")]
+        public void HelpOptionCanBeSet()
+        {
+            var app = new CommandLineApplication();
+            var optHelp = app.HelpOption("-?");
+
+            app.Execute("-?");
+
+            Assert.True(optHelp.HasValue());
+        }
+
+        [Fact(Skip = "As of version 1.1.0 giving the version option aborts processing without settig it")]
+        public void VersionOptionCanBeSet()
+        {
+            var app = new CommandLineApplication();
+            var optVersion = app.VersionOption("-V", "1", "1.0");
+
+            app.Execute("-V");
+
+            Assert.True(optVersion.HasValue());
+        }
+
+        [Theory]
+        [InlineData("-v:true")]
+        [InlineData("--verbose:true")]
+        public void ThrowsExceptionOnNoValueOptionHavingValue(string inputOption)
+        {
+            var app = new CommandLineApplication();
+            app.Option("-v |--verbose", "be verbose", CommandOptionType.NoValue);
+
+            var exception = Assert.Throws<CommandParsingException>(() => app.Execute(inputOption));
+
+            Assert.Equal("Unexpected value 'true' for option 'verbose'", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnEmptyCommandOrArgument()
+        {
+            string inputOption = String.Empty;
+            var app = new CommandLineApplication();
+
+            var exception = Assert.Throws<CommandParsingException>(() => app.Execute(inputOption));
+
+            Assert.Equal($"Unrecognized command or argument '{inputOption}'", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnInvalidOption()
+        {
+            string inputOption = "-";
+            var app = new CommandLineApplication();
+
+            var exception = Assert.Throws<CommandParsingException>(() => app.Execute(inputOption));
+
+            Assert.Equal($"Unrecognized option '{inputOption}'", exception.Message);
         }
     }
 }

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -607,7 +607,7 @@ Examples:
         [InlineData(new[] { "-h", "-f" }, "some flag")]
         public void HelpAndVersionOptionStopProcessing(string[] input, string expectedOutData)
         {
-            using (StringWriter outWriter = new StringWriter())
+            using (var outWriter = new StringWriter())
             {
                 var app = new CommandLineApplication { Out = outWriter };
                 app.HelpOption("-h --help");
@@ -617,7 +617,7 @@ Examples:
                 app.Execute(input);
 
                 outWriter.Flush();
-                string outData = outWriter.ToString();
+                var outData = outWriter.ToString();
                 Assert.Contains(expectedOutData, outData);
                 Assert.False(optFlag.HasValue());
             }
@@ -650,28 +650,6 @@ Examples:
             Assert.True(optVerbose.HasValue());
         }
 
-        [Fact(Skip = "Until now giving the help option aborts processing without settig it")]
-        public void HelpOptionCanBeSet()
-        {
-            var app = new CommandLineApplication();
-            var optHelp = app.HelpOption("-?");
-
-            app.Execute("-?");
-
-            Assert.True(optHelp.HasValue());
-        }
-
-        [Fact(Skip = "Until now giving the version option aborts processing without settig it")]
-        public void VersionOptionCanBeSet()
-        {
-            var app = new CommandLineApplication();
-            var optVersion = app.VersionOption("-V", "1", "1.0");
-
-            app.Execute("-V");
-
-            Assert.True(optVersion.HasValue());
-        }
-
         [Theory]
         [InlineData("-v:true")]
         [InlineData("--verbose:true")]
@@ -688,7 +666,7 @@ Examples:
         [Fact]
         public void ThrowsExceptionOnEmptyCommandOrArgument()
         {
-            string inputOption = String.Empty;
+            var inputOption = String.Empty;
             var app = new CommandLineApplication();
 
             var exception = Assert.Throws<CommandParsingException>(() => app.Execute(inputOption));
@@ -699,7 +677,7 @@ Examples:
         [Fact]
         public void ThrowsExceptionOnInvalidOption()
         {
-            string inputOption = "-";
+            var inputOption = "-";
             var app = new CommandLineApplication();
 
             var exception = Assert.Throws<CommandParsingException>(() => app.Execute(inputOption));


### PR DESCRIPTION
There are two tests that are marked to be skipped for now in order to
not break the build.
Both don't really uncover bugs but rather counterintuitive behaviour
regarding the special treatment of the help and version option that
probably isnt't problematic in most cases.