### PR TITLE
Check for abstract types in ActivatorUtilities

### DIFF
--- a/shared/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs
+++ b/shared/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs
@@ -23,21 +23,24 @@ namespace Microsoft.Extensions.Internal
             int bestLength = -1;
             ConstructorMatcher bestMatcher = null;
 
-            foreach (var matcher in instanceType
-                .GetTypeInfo()
-                .DeclaredConstructors
-                .Where(c => !c.IsStatic && c.IsPublic)
-                .Select(constructor => new ConstructorMatcher(constructor)))
+            if (!instanceType.GetTypeInfo().IsAbstract)
             {
-                var length = matcher.Match(parameters);
-                if (length == -1)
+                foreach (var matcher in instanceType
+                    .GetTypeInfo()
+                    .DeclaredConstructors
+                    .Where(c => !c.IsStatic && c.IsPublic)
+                    .Select(constructor => new ConstructorMatcher(constructor)))
                 {
-                    continue;
-                }
-                if (bestLength < length)
-                {
-                    bestLength = length;
-                    bestMatcher = matcher;
+                    var length = matcher.Match(parameters);
+                    if (length == -1)
+                    {
+                        continue;
+                    }
+                    if (bestLength < length)
+                    {
+                        bestLength = length;
+                        bestMatcher = matcher;
+                    }
                 }
             }
 

--- a/test/Microsoft.Extensions.Internal.Test/ActivatorUtilitiesTests.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ActivatorUtilitiesTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Extensions.Internal
+{
+    public class ActivatorUtilitiesTests
+    {
+        [Fact]
+        public void CreateInstance_WithAbstractTypeAndPublicConstructor_ThrowsCorrectException()
+        {
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => ActivatorUtilities.CreateInstance(default(IServiceProvider), typeof(AbstractFoo)));
+            var msg = "A suitable constructor for type 'Microsoft.Extensions.Internal.AbstractFoo' could not be located. Ensure the type is concrete and services are registered for all parameters of a public constructor.";
+            Assert.Equal(msg, ex.Message);
+        }
+    }
+
+    abstract class AbstractFoo
+    {
+        // The constructor should be public, since that is checked as well.
+        public AbstractFoo()
+        {
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
+++ b/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.Extensions.ActivatorUtilities.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.ClosedGenericMatcher.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.CopyOnWriteDictionary.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.DotnetToolDispatcher.Sources\**\*.cs" />


### PR DESCRIPTION
The exception asks the user to make sure the type is concrete, however this is not being checked.