### PR TITLE
	Only catch TargetInvocationException's

### DIFF
--- a/shared/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs
+++ b/shared/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Extensions.Internal
                 {
                     return _constructor.Invoke(_parameterValues);
                 }
-                catch (Exception ex)
+                catch (TargetInvocationException ex)
                 {
                     ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                     // The above line will always throw, but the compiler requires we throw explicitly.

--- a/test/Microsoft.Extensions.Internal.Test/ActivatorUtilitiesTests.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ActivatorUtilitiesTests.cs
@@ -16,6 +16,15 @@ namespace Microsoft.Extensions.Internal
             var msg = "A suitable constructor for type 'Microsoft.Extensions.Internal.AbstractFoo' could not be located. Ensure the type is concrete and services are registered for all parameters of a public constructor.";
             Assert.Equal(msg, ex.Message);
         }
+
+        [Fact]
+        public void CreateInstance_CapturesInnerException_OfTargetInvocationException()
+        {
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => ActivatorUtilities.CreateInstance(default(IServiceProvider), typeof(Bar)));
+            var msg = "some error";
+            Assert.Equal(msg, ex.Message);
+        }
     }
 
     abstract class AbstractFoo
@@ -23,6 +32,14 @@ namespace Microsoft.Extensions.Internal
         // The constructor should be public, since that is checked as well.
         public AbstractFoo()
         {
+        }
+    }
+
+    class Bar
+    {
+        public Bar()
+        {
+            throw new InvalidOperationException("some error");
         }
     }
 }


### PR DESCRIPTION
There might be cases when the inner exception is null. This results in another exception from `ExceptionDispatchInfo.Capture` because the `source` parameter is `null`.