### PR TITLE
Flatten out AggregateException

### DIFF
--- a/shared/Microsoft.Extensions.StackTrace.Sources/ExceptionDetailsProvider.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/ExceptionDetailsProvider.cs
@@ -57,15 +57,15 @@ namespace Microsoft.Extensions.StackTrace.Sources
             }
 
             var list = new List<Exception>();
-            if (ex.GetType().IsAssignableFrom(typeof(AggregateException)))
+            if (ex is AggregateException aggregateException)
             {
                 list.Add(ex);
-                var exception = (AggregateException) ex;
-                foreach (var innerException in exception.Flatten().InnerExceptions)
+                foreach (var innerException in aggregateException.Flatten().InnerExceptions)
                 {
                     list.Add(innerException);
                 }
             }
+
             else
             {
                 while (ex != null)
@@ -73,9 +73,9 @@ namespace Microsoft.Extensions.StackTrace.Sources
                     list.Add(ex);
                     ex = ex.InnerException;
                 }
+                list.Reverse();
             }
 
-            list.Reverse();
             return list;
         }
 

--- a/shared/Microsoft.Extensions.StackTrace.Sources/ExceptionDetailsProvider.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/ExceptionDetailsProvider.cs
@@ -57,11 +57,24 @@ namespace Microsoft.Extensions.StackTrace.Sources
             }
 
             var list = new List<Exception>();
-            while (ex != null)
+            if (ex.GetType().IsAssignableFrom(typeof(AggregateException)))
             {
                 list.Add(ex);
-                ex = ex.InnerException;
+                var exception = (AggregateException) ex;
+                foreach (var innerException in exception.Flatten().InnerExceptions)
+                {
+                    list.Add(innerException);
+                }
             }
+            else
+            {
+                while (ex != null)
+                {
+                    list.Add(ex);
+                    ex = ex.InnerException;
+                }
+            }
+
             list.Reverse();
             return list;
         }


### PR DESCRIPTION
Inner exceptions were not being listed, only the first one was:
![capture](https://cloud.githubusercontent.com/assets/6234561/25026234/689626f4-205a-11e7-9c38-5bc60f8e1acd.PNG)



With this change, all inner exceptions are flattened and added to the list that is displayed:
![capture2](https://cloud.githubusercontent.com/assets/6234561/25026236/6c2cceee-205a-11e7-99ab-ea719878d439.PNG)

cc @pranavkm 

Addresses aspnet/Diagnostics#356