### PR TITLE
Add ObjectMethodExecutor shared-source package

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -7,6 +7,7 @@
       "Microsoft.Extensions.CommandLineUtils.Sources": {},
       "Microsoft.Extensions.CopyOnWriteDictionary.Sources": {},
       "Microsoft.Extensions.HashCodeCombiner.Sources": {},
+      "Microsoft.Extensions.ObjectMethodExecutor.Sources": {},
       "Microsoft.Extensions.Process.Sources": {},
       "Microsoft.Extensions.PropertyActivator.Sources": {},
       "Microsoft.Extensions.PropertyHelper.Sources": {},

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutor.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutor.cs
@@ -1,0 +1,454 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.Internal
+{
+    public class ObjectMethodExecutor
+    {
+        private readonly object[] _parameterDefaultValues;
+        private readonly MethodExecutorAsync _executorAsync;
+        private readonly MethodExecutor _executor;
+
+        private static readonly ConstructorInfo _objectMethodExecutorAwaitableConstructor =
+            typeof(ObjectMethodExecutorAwaitable).GetConstructor(new[] {
+                typeof(object),                 // customAwaitable
+                typeof(Func<object, object>),   // getAwaiterMethod
+                typeof(Func<object, bool>),     // isCompletedMethod
+                typeof(Func<object, object>),   // getResultMethod
+                typeof(Action<object, Action>), // onCompletedMethod
+                typeof(Action<object, Action>)  // unsafeOnCompletedMethod
+            });
+
+        private ObjectMethodExecutor(MethodInfo methodInfo, TypeInfo targetTypeInfo, object[] parameterDefaultValues)
+        {
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            MethodInfo = methodInfo;
+            MethodParameters = methodInfo.GetParameters();
+            TargetTypeInfo = targetTypeInfo;
+            MethodReturnType = methodInfo.ReturnType;
+
+            var isAwaitable = IsAwaitable(MethodReturnType,
+                out var getAwaiterMethod,
+                out var awaiterType,
+                out var awaiterResultType,
+                out var awaiterIsCompletedProperty,
+                out var awaiterGetResultMethod,
+                out var awaiterOnCompletedMethod,
+                out var awaiterUnsafeOnCompletedMethod);
+
+            IsMethodAsync = isAwaitable;
+            AsyncResultType = isAwaitable ? awaiterResultType : null;
+
+            // Upstream code may prefer to use the sync-executor even for async methods, because if it knows
+            // that the result is a specific Task<T> where T is known, then it can directly cast to that type
+            // and await it without the extra heap allocations involved in the _executorAsync code path.
+            _executor = GetExecutor(methodInfo, targetTypeInfo);
+
+            if (IsMethodAsync)
+            {
+                _executorAsync = GetExecutorAsync(
+                    methodInfo,
+                    targetTypeInfo,
+                    getAwaiterMethod,
+                    awaiterType,
+                    awaiterResultType,
+                    awaiterIsCompletedProperty,
+                    awaiterGetResultMethod,
+                    awaiterOnCompletedMethod,
+                    awaiterUnsafeOnCompletedMethod);
+            }
+
+            _parameterDefaultValues = parameterDefaultValues;
+        }
+
+        private delegate ObjectMethodExecutorAwaitable MethodExecutorAsync(object target, object[] parameters);
+
+        private delegate object MethodExecutor(object target, object[] parameters);
+
+        private delegate void VoidMethodExecutor(object target, object[] parameters);
+
+        public MethodInfo MethodInfo { get; }
+
+        public ParameterInfo[] MethodParameters { get; }
+
+        public TypeInfo TargetTypeInfo { get; }
+
+        public Type AsyncResultType { get; }
+
+        // This field is made internal set because it is set in unit tests.
+        public Type MethodReturnType { get; internal set; }
+
+        public bool IsMethodAsync { get; }
+
+        public static ObjectMethodExecutor Create(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {
+            return new ObjectMethodExecutor(methodInfo, targetTypeInfo, null);
+        }
+
+        public static ObjectMethodExecutor Create(MethodInfo methodInfo, TypeInfo targetTypeInfo, object[] parameterDefaultValues)
+        {
+            if (parameterDefaultValues == null)
+            {
+                throw new ArgumentNullException(nameof(parameterDefaultValues));
+            }
+
+            return new ObjectMethodExecutor(methodInfo, targetTypeInfo, parameterDefaultValues);
+        }
+
+        /// <summary>
+        /// Executes the configured method on <paramref name="target"/>. This can be used whether or not
+        /// the configured method is asynchronous.
+        /// </summary>
+        /// <remarks>
+        /// Even if the target method is asynchronous, it's desirable to invoke it using Execute rather than
+        /// ExecuteAsync if you know at compile time what the return type is, because then you can directly
+        /// "await" that value (via a cast), and then the generated code will be able to reference the
+        /// resulting awaitable as a value-typed variable. If you use ExecuteAsync instead, the generated
+        /// code will have to treat the resulting awaitable as a boxed object, because it doesn't know at
+        /// compile time what type it would be.
+        /// </remarks>
+        /// <param name="target">The object whose method is to be executed.</param>
+        /// <param name="parameters">Parameters to pass to the method.</param>
+        /// <returns>The method return value.</returns>
+        public object Execute(object target, object[] parameters)
+        {
+            return _executor(target, parameters);
+        }
+
+        /// <summary>
+        /// Executes the configured method on <paramref name="target"/>. This can only be used if the configured
+        /// method is asynchronous.
+        /// </summary>
+        /// <remarks>
+        /// If you don't know at compile time the type of the method's returned awaitable, you can use ExecuteAsync,
+        /// which supplies an awaitable-of-object. This always works, but can incur several extra heap allocations
+        /// as compared with using Execute and then using "await" on the result value typecasted to the known
+        /// awaitable type. The possible extra heap allocations are for:
+        /// 
+        /// 1. The custom awaitable (though usually there's a heap allocation for this anyway, since normally
+        ///    it's a reference type, and you normally create a new instance per call).
+        /// 2. The custom awaiter (whether or not it's a value type, since if it's not, you need a new instance
+        ///    of it, and if it is, it will have to be boxed so the calling code can reference it as an object).
+        /// 3. The async result value, if it's a value type (it has to be boxed as an object, since the calling
+        ///    code doesn't know what type it's going to be).
+        /// </remarks>
+        /// <param name="target">The object whose method is to be executed.</param>
+        /// <param name="parameters">Parameters to pass to the method.</param>
+        /// <returns>An object that you can "await" to get the method return value.</returns>
+        public ObjectMethodExecutorAwaitable ExecuteAsync(object target, object[] parameters)
+        {
+            return _executorAsync(target, parameters);
+        }
+
+        public object GetDefaultValueForParameter(int index)
+        {
+            if (_parameterDefaultValues == null)
+            {
+                throw new InvalidOperationException($"Cannot call {nameof(GetDefaultValueForParameter)}, because no parameter default values were supplied.");
+            }
+
+            if (index < 0 || index > MethodParameters.Length - 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return _parameterDefaultValues[index];
+        }
+
+        private static MethodExecutor GetExecutor(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {
+            // Parameters to executor
+            var targetParameter = Expression.Parameter(typeof(object), "target");
+            var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
+
+            // Build parameter list
+            var parameters = new List<Expression>();
+            var paramInfos = methodInfo.GetParameters();
+            for (int i = 0; i < paramInfos.Length; i++)
+            {
+                var paramInfo = paramInfos[i];
+                var valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
+                var valueCast = Expression.Convert(valueObj, paramInfo.ParameterType);
+
+                // valueCast is "(Ti) parameters[i]"
+                parameters.Add(valueCast);
+            }
+
+            // Call method
+            var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
+            var methodCall = Expression.Call(instanceCast, methodInfo, parameters);
+
+            // methodCall is "((Ttarget) target) method((T0) parameters[0], (T1) parameters[1], ...)"
+            // Create function
+            if (methodCall.Type == typeof(void))
+            {
+                var lambda = Expression.Lambda<VoidMethodExecutor>(methodCall, targetParameter, parametersParameter);
+                var voidExecutor = lambda.Compile();
+                return WrapVoidMethod(voidExecutor);
+            }
+            else
+            {
+                // must coerce methodCall to match ActionExecutor signature
+                var castMethodCall = Expression.Convert(methodCall, typeof(object));
+                var lambda = Expression.Lambda<MethodExecutor>(castMethodCall, targetParameter, parametersParameter);
+                return lambda.Compile();
+            }
+        }
+
+        private static MethodExecutor WrapVoidMethod(VoidMethodExecutor executor)
+        {
+            return delegate (object target, object[] parameters)
+            {
+                executor(target, parameters);
+                return null;
+            };
+        }
+
+        private static MethodExecutorAsync GetExecutorAsync(
+            MethodInfo methodInfo,
+            TypeInfo targetTypeInfo,
+            MethodInfo getAwaiterMethod,
+            Type awaiterType,
+            Type awaiterResultType,
+            PropertyInfo awaiterIsCompletedProperty,
+            MethodInfo awaiterGetResultMethod,
+            MethodInfo awaiterOnCompletedMethod,
+            MethodInfo awaiterUnsafeOnCompletedMethod)
+        {
+            // Parameters to executor
+            var targetParameter = Expression.Parameter(typeof(object), "target");
+            var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
+
+            // Build parameter list
+            var parameters = new List<Expression>();
+            var paramInfos = methodInfo.GetParameters();
+            for (int i = 0; i < paramInfos.Length; i++)
+            {
+                var paramInfo = paramInfos[i];
+                var valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
+                var valueCast = Expression.Convert(valueObj, paramInfo.ParameterType);
+
+                // valueCast is "(Ti) parameters[i]"
+                parameters.Add(valueCast);
+            }
+
+            // Call method
+            var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
+            var methodCall = Expression.Call(instanceCast, methodInfo, parameters);
+
+            // Using the method return value, construct an ObjectMethodExecutorAwaitable based on
+            // the info we have about its implementation of the awaitable pattern. Note that all
+            // the funcs/actions we construct here are precompiled, so that only one instance of
+            // each is preserved throughout the lifetime of the ObjectMethodExecutor.
+
+            // var getAwaiterFunc = (object awaitable) =>
+            //     (object)((CustomAwaitableType)awaitable).GetAwaiter();
+            var customAwaiterParam = Expression.Parameter(typeof(object), "awaitable");
+            var getAwaiterFunc = Expression.Lambda<Func<object, object>>(
+                Expression.Convert(
+                    Expression.Call(
+                        Expression.Convert(customAwaiterParam, methodInfo.ReturnType),
+                        getAwaiterMethod),
+                    typeof(object)),
+                customAwaiterParam).Compile();
+
+            // var isCompletedFunc = (object awaiter) =>
+            //     ((CustomAwaiterType)awaiter).IsCompleted;
+            var isCompletedParam = Expression.Parameter(typeof(object), "awaiter");
+            var isCompletedFunc = Expression.Lambda<Func<object, bool>>(
+                Expression.MakeMemberAccess(
+                    Expression.Convert(isCompletedParam, awaiterType),
+                    awaiterIsCompletedProperty),
+                isCompletedParam).Compile();
+
+            var getResultParam = Expression.Parameter(typeof(object), "awaiter");
+            Func<object, object> getResultFunc;
+            if (awaiterResultType == typeof(void))
+            {
+                // var getResultFunc = (object awaiter) =>
+                // {
+                //     ((CustomAwaiterType)awaiter).GetResult(); // We need to invoke this to surface any exceptions
+                //     return (object)null;
+                // };
+                getResultFunc = Expression.Lambda<Func<object, object>>(
+                    Expression.Block(
+                        Expression.Call(
+                            Expression.Convert(getResultParam, awaiterType),
+                            awaiterGetResultMethod),
+                        Expression.Constant(null)
+                    ),
+                    getResultParam).Compile();
+            }
+            else
+            {
+                // var getResultFunc = (object awaiter) =>
+                //     (object)((CustomAwaiterType)awaiter).GetResult();
+                getResultFunc = Expression.Lambda<Func<object, object>>(
+                    Expression.Convert(
+                        Expression.Call(
+                            Expression.Convert(getResultParam, awaiterType),
+                            awaiterGetResultMethod),
+                        typeof(object)),
+                    getResultParam).Compile();
+            }
+
+            // var onCompletedFunc = (object awaiter, Action continuation) => {
+            //     ((CustomAwaiterType)awaiter).OnCompleted(continuation);
+            // };
+            var onCompletedParam1 = Expression.Parameter(typeof(object), "awaiter");
+            var onCompletedParam2 = Expression.Parameter(typeof(Action), "continuation");
+            var onCompletedFunc = Expression.Lambda<Action<object, Action>>(
+                Expression.Call(
+                    Expression.Convert(onCompletedParam1, awaiterType),
+                    awaiterOnCompletedMethod,
+                    onCompletedParam2),
+                onCompletedParam1,
+                onCompletedParam2).Compile();
+
+            Action<object, Action> unsafeOnCompletedFunc = null;
+            if (awaiterUnsafeOnCompletedMethod != null)
+            {
+                // var unsafeOnCompletedFunc = (object awaiter, Action continuation) => {
+                //     ((CustomAwaiterType)awaiter).UnsafeOnCompleted(continuation);
+                // };
+                var unsafeOnCompletedParam1 = Expression.Parameter(typeof(object), "awaiter");
+                var unsafeOnCompletedParam2 = Expression.Parameter(typeof(Action), "continuation");
+                unsafeOnCompletedFunc = Expression.Lambda<Action<object, Action>>(
+                    Expression.Call(
+                        Expression.Convert(unsafeOnCompletedParam1, awaiterType),
+                        awaiterUnsafeOnCompletedMethod,
+                        unsafeOnCompletedParam2),
+                    unsafeOnCompletedParam1,
+                    unsafeOnCompletedParam2).Compile();
+            }
+
+            // return new ObjectMethodExecutorAwaitable(
+            //     (object)getCustomAwaitable(),
+            //     getAwaiterFunc,
+            //     isCompletedFunc,
+            //     getResultFunc,
+            //     onCompletedFunc,
+            //     unsafeOnCompletedFunc);
+            var returnValueExpression = Expression.New(
+                _objectMethodExecutorAwaitableConstructor,
+                Expression.Convert(methodCall, typeof(object)),
+                Expression.Constant(getAwaiterFunc),
+                Expression.Constant(isCompletedFunc),
+                Expression.Constant(getResultFunc),
+                Expression.Constant(onCompletedFunc),
+                Expression.Constant(unsafeOnCompletedFunc, typeof(Action<object, Action>)));
+
+            var lambda = Expression.Lambda<MethodExecutorAsync>(returnValueExpression, targetParameter, parametersParameter);
+            return lambda.Compile();
+        }
+
+        private static bool IsAwaitable(
+            Type type,
+            out MethodInfo getAwaiterMethod,
+            out Type awaiterType,
+            out Type returnType,
+            out PropertyInfo isCompletedProperty,
+            out MethodInfo getResultMethod,
+            out MethodInfo onCompletedMethod,
+            out MethodInfo unsafeOnCompletedMethod)
+        {
+            // Based on Roslyn code: http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ISymbolExtensions.cs,db4d48ba694b9347
+
+            // Awaitable must have method matching "object GetAwaiter()"
+            getAwaiterMethod = type.GetRuntimeMethods().FirstOrDefault(m => 
+                m.Name.Equals("GetAwaiter", StringComparison.OrdinalIgnoreCase)
+                && m.GetParameters().Length == 0
+                && m.ReturnType != null);
+            if (getAwaiterMethod == null)
+            {
+                awaiterType = null;
+                isCompletedProperty = null;
+                onCompletedMethod = null;
+                unsafeOnCompletedMethod = null;
+                getResultMethod = null;
+                returnType = null;
+                return false;
+            }
+
+            awaiterType = getAwaiterMethod.ReturnType;
+
+            // Awaiter must have property matching "bool IsCompleted { get; }"
+            isCompletedProperty = awaiterType.GetRuntimeProperties().FirstOrDefault(p =>
+                p.Name.Equals("IsCompleted", StringComparison.OrdinalIgnoreCase)
+                && p.PropertyType == typeof(bool)
+                && p.GetMethod != null);
+            if (isCompletedProperty == null)
+            {
+                onCompletedMethod = null;
+                unsafeOnCompletedMethod = null;
+                getResultMethod = null;
+                returnType = null;
+                return false;
+            }
+
+            // Awaiter must implement INotifyCompletion
+            var awaiterInterfaces = awaiterType.GetInterfaces();
+            var implementsINotifyCompletion = awaiterInterfaces.Any(t => t == typeof(INotifyCompletion));
+            if (implementsINotifyCompletion)
+            {
+                // INotifyCompletion supplies a method matching "void OnCompleted(Action action)"
+                var interfaceMap = awaiterType.GetTypeInfo().GetRuntimeInterfaceMap(typeof(INotifyCompletion));
+                onCompletedMethod = interfaceMap.InterfaceMethods.Single(m =>
+                    m.Name.Equals("OnCompleted", StringComparison.OrdinalIgnoreCase)
+                    && m.ReturnType == typeof(void)
+                    && m.GetParameters().Length == 1
+                    && m.GetParameters()[0].ParameterType == typeof(Action));
+            }
+            else
+            {
+                onCompletedMethod = null;
+                unsafeOnCompletedMethod = null;
+                getResultMethod = null;
+                returnType = null;
+                return false;
+            }
+
+            // Awaiter optionally implements ICriticalNotifyCompletion
+            var implementsICriticalNotifyCompletion = awaiterInterfaces.Any(t => t == typeof(ICriticalNotifyCompletion));
+            if (implementsICriticalNotifyCompletion)
+            {
+                // ICriticalNotifyCompletion supplies a method matching "void UnsafeOnCompleted(Action action)"
+                var interfaceMap = awaiterType.GetTypeInfo().GetRuntimeInterfaceMap(typeof(ICriticalNotifyCompletion));
+                unsafeOnCompletedMethod = interfaceMap.InterfaceMethods.Single(m =>
+                    m.Name.Equals("UnsafeOnCompleted", StringComparison.OrdinalIgnoreCase)
+                    && m.ReturnType == typeof(void)
+                    && m.GetParameters().Length == 1
+                    && m.GetParameters()[0].ParameterType == typeof(Action));
+            }
+            else
+            {
+                unsafeOnCompletedMethod = null;
+            }
+
+            // Awaiter must have method matching "void GetResult" or "T GetResult()"
+            getResultMethod = awaiterType.GetRuntimeMethods().FirstOrDefault(m =>
+                m.Name.Equals("GetResult")
+                && m.GetParameters().Length == 0);
+            if (getResultMethod == null)
+            {
+                returnType = null;
+                return false;
+            }
+
+            returnType = getResultMethod.ReturnType;
+            return true;
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutorAwaitable.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutorAwaitable.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.Internal
+{
+    /// <summary>
+    /// Provides a common awaitable structure that <see cref="ObjectMethodExecutor.ExecuteAsync"/> can
+    /// return, regardless of whether the underlying value is a System.Task, an FSharpAsync, or an
+    /// application-defined custom awaitable.
+    /// </summary>
+    public struct ObjectMethodExecutorAwaitable
+    {
+        private readonly object _customAwaitable;
+        private readonly Func<object, object> _getAwaiterMethod;
+        private readonly Func<object, bool> _isCompletedMethod;
+        private readonly Func<object, object> _getResultMethod;
+        private readonly Action<object, Action> _onCompletedMethod;
+        private readonly Action<object, Action> _unsafeOnCompletedMethod;
+
+        // Perf note: since we're requiring the customAwaitable to be supplied here as an object,
+        // this will trigger a further allocation if it was a value type (i.e., to box it). We can't
+        // fix this by making the customAwaitable type generic, because the calling code typically
+        // does not know the type of the awaitable/awaiter at compile-time anyway.
+        //
+        // However, we could fix it by not passing the customAwaitable here at all, and instead
+        // passing a func that maps directly from the target object (e.g., controller instance),
+        // target method (e.g., action method info), and params array to the custom awaiter in the
+        // GetAwaiter() method below. In effect, by delaying the actual method call until the
+        // upstream code calls GetAwaiter on this ObjectMethodExecutorAwaitable instance.
+        // This optimization is not currently implemented because:
+        // [1] It would make no difference when the awaitable was an object type, which is
+        //     by far the most common scenario (e.g., System.Task<T>).
+        // [2] It would be complex - we'd need some kind of object pool to track all the parameter
+        //     arrays until we needed to use them in GetAwaiter().
+        // We can reconsider this in the future if there's a need to optimize for ValueTask<T>
+        // or other value-typed awaitables.
+
+        public ObjectMethodExecutorAwaitable(
+            object customAwaitable,
+            Func<object, object> getAwaiterMethod,
+            Func<object, bool> isCompletedMethod,
+            Func<object, object> getResultMethod,
+            Action<object, Action> onCompletedMethod,
+            Action<object, Action> unsafeOnCompletedMethod)
+        {
+            _customAwaitable = customAwaitable;
+            _getAwaiterMethod = getAwaiterMethod;
+            _isCompletedMethod = isCompletedMethod;
+            _getResultMethod = getResultMethod;
+            _onCompletedMethod = onCompletedMethod;
+            _unsafeOnCompletedMethod = unsafeOnCompletedMethod;
+        }
+
+        public Awaiter GetAwaiter()
+        {
+            var customAwaiter = _getAwaiterMethod(_customAwaitable);
+            return new Awaiter(customAwaiter, _isCompletedMethod, _getResultMethod, _onCompletedMethod, _unsafeOnCompletedMethod);
+        }
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            private readonly object _customAwaiter;
+            private readonly Func<object, bool> _isCompletedMethod;
+            private readonly Func<object, object> _getResultMethod;
+            private readonly Action<object, Action> _onCompletedMethod;
+            private readonly Action<object, Action> _unsafeOnCompletedMethod;
+
+            public Awaiter(
+                object customAwaiter,
+                Func<object, bool> isCompletedMethod,
+                Func<object, object> getResultMethod,
+                Action<object, Action> onCompletedMethod,
+                Action<object, Action> unsafeOnCompletedMethod)
+            {
+                _customAwaiter = customAwaiter;
+                _isCompletedMethod = isCompletedMethod;
+                _getResultMethod = getResultMethod;
+                _onCompletedMethod = onCompletedMethod;
+                _unsafeOnCompletedMethod = unsafeOnCompletedMethod;
+            }
+
+            public bool IsCompleted => _isCompletedMethod(_customAwaiter);
+
+            public object GetResult() => _getResultMethod(_customAwaiter);
+
+            public void OnCompleted(Action continuation)
+            {
+                _onCompletedMethod(_customAwaiter, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                // If the underlying awaitable implements ICriticalNotifyCompletion, use its UnsafeOnCompleted.
+                // If not, fall back on using its OnCompleted.
+                //
+                // Why this is safe:
+                // - Implementing ICriticalNotifyCompletion is a way of saying the caller can choose whether it
+                //   needs the execution context to be preserved (which it signals by calling OnCompleted), or
+                //   that it doesn't (which it signals by calling UnsafeOnCompleted). Obviously it's faster *not*
+                //   to preserve and restore the context, so we prefer that where possible.
+                // - If a caller doesn't need the execution context to be preserved and hence calls UnsafeOnCompleted,
+                //   there's no harm in preserving it anyway - it's just a bit of wasted cost. That's what will happen
+                //   if a caller sees that the proxy implements ICriticalNotifyCompletion but the proxy chooses to
+                //   pass the call on to the underlying awaitable's OnCompleted method.
+
+                var underlyingMethodToUse = _unsafeOnCompletedMethod ?? _onCompletedMethod;
+                underlyingMethodToUse(_customAwaiter, continuation);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
+++ b/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\..\shared\Microsoft.Extensions.CopyOnWriteDictionary.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.DotnetToolDispatcher.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.HashCodeCombiner.Sources\**\*.cs" />
+    <Compile Include="..\..\shared\Microsoft.Extensions.ObjectMethodExecutor.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.PropertyActivator.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.PropertyHelper.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.SecurityHelper.Sources\**\*.cs" />
@@ -26,6 +27,10 @@
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/test/Microsoft.Extensions.Internal.Test/ObjectMethodExecutorTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ObjectMethodExecutorTest.cs
@@ -1,0 +1,540 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.Internal
+{
+    public class ObjectMethodExecutorTest
+    {
+        private TestObject _targetObject = new TestObject();
+        private TypeInfo targetTypeInfo = typeof(TestObject).GetTypeInfo();
+
+        [Fact]
+        public void ExecuteValueMethod()
+        {
+            var executor = GetExecutorForMethod("ValueMethod");
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { 10, 20 });
+            Assert.Equal(30, (int)result);
+        }
+
+        [Fact]
+        public void ExecuteVoidValueMethod()
+        {
+            var executor = GetExecutorForMethod("VoidValueMethod");
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { 10 });
+            Assert.Same(null, result);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodWithReturnType()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnType");
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { 10 });
+            var resultObject = Assert.IsType<TestObject>(result);
+            Assert.Equal("Hello", resultObject.value);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodUpdateValue()
+        {
+            var executor = GetExecutorForMethod("ValueMethodUpdateValue");
+            var parameter = new TestObject();
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { parameter });
+            var resultObject = Assert.IsType<TestObject>(result);
+            Assert.Equal("HelloWorld", resultObject.value);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodWithReturnTypeThrowsException()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnTypeThrowsException");
+            var parameter = new TestObject();
+            Assert.Throws<NotImplementedException>(
+                        () => executor.Execute(
+                            _targetObject,
+                            new object[] { parameter }));
+        }
+
+        [Fact]
+        public async Task ExecuteValueMethodAsync()
+        {
+            var executor = GetExecutorForMethod("ValueMethodAsync");
+            var result = await executor.ExecuteAsync(
+                _targetObject,
+                new object[] { 10, 20 });
+            Assert.Equal(30, (int)result);
+        }
+
+        [Fact]
+        public async Task ExecuteValueMethodWithReturnTypeAsync()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnTypeAsync");
+            var result = await executor.ExecuteAsync(
+                _targetObject,
+                new object[] { 10 });
+            var resultObject = Assert.IsType<TestObject>(result);
+            Assert.Equal("Hello", resultObject.value);
+        }
+
+        [Fact]
+        public async Task ExecuteValueMethodUpdateValueAsync()
+        {
+            var executor = GetExecutorForMethod("ValueMethodUpdateValueAsync");
+            var parameter = new TestObject();
+            var result = await executor.ExecuteAsync(
+                _targetObject,
+                new object[] { parameter });
+            var resultObject = Assert.IsType<TestObject>(result);
+            Assert.Equal("HelloWorld", resultObject.value);
+        }
+
+        [Fact]
+        public async Task ExecuteValueMethodWithReturnTypeThrowsExceptionAsync()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnTypeThrowsExceptionAsync");
+            var parameter = new TestObject();
+            await Assert.ThrowsAsync<NotImplementedException>(
+                    async () => await executor.ExecuteAsync(
+                            _targetObject,
+                            new object[] { parameter }));
+        }
+
+        [Fact]
+        public async Task ExecuteValueMethodWithReturnVoidThrowsExceptionAsync()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnVoidThrowsExceptionAsync");
+            var parameter = new TestObject();
+            await Assert.ThrowsAsync<NotImplementedException>(
+                    async () => await executor.ExecuteAsync(
+                            _targetObject,
+                            new object[] { parameter }));
+        }
+
+        [Fact]
+        public void GetDefaultValueForParameters_ReturnsSuppliedValues()
+        {
+            var suppliedDefaultValues = new object[] { 123, "test value" };
+            var executor = GetExecutorForMethod("MethodWithMultipleParameters", suppliedDefaultValues);
+            Assert.Equal(suppliedDefaultValues[0], executor.GetDefaultValueForParameter(0));
+            Assert.Equal(suppliedDefaultValues[1], executor.GetDefaultValueForParameter(1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => executor.GetDefaultValueForParameter(2));
+        }
+
+        [Fact]
+        public void GetDefaultValueForParameters_ThrowsIfNoneWereSupplied()
+        {
+            var executor = GetExecutorForMethod("MethodWithMultipleParameters");
+            Assert.Throws<InvalidOperationException>(() => executor.GetDefaultValueForParameter(0));
+        }
+
+        [Fact]
+        public async void TargetMethodReturningCustomAwaitableOfReferenceType_CanInvokeViaExecute()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("CustomAwaitableOfReferenceTypeAsync");
+
+            // Act
+            var result = await (TestAwaitable<TestObject>)executor.Execute(_targetObject, new object[] { "Hello", 123 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(TestObject), executor.AsyncResultType);
+            Assert.NotNull(result);
+            Assert.Equal("Hello 123", result.value);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningCustomAwaitableOfValueType_CanInvokeViaExecute()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("CustomAwaitableOfValueTypeAsync");
+
+            // Act
+            var result = await (TestAwaitable<int>)executor.Execute(_targetObject, new object[] { 123, 456 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(int), executor.AsyncResultType);
+            Assert.NotNull(result);
+            Assert.Equal(579, result);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningCustomAwaitableOfReferenceType_CanInvokeViaExecuteAsync()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("CustomAwaitableOfReferenceTypeAsync");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[] { "Hello", 123 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(TestObject), executor.AsyncResultType);
+            Assert.NotNull(result);
+            Assert.IsType(typeof(TestObject), result);
+            Assert.Equal("Hello 123", ((TestObject)result).value);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningCustomAwaitableOfValueType_CanInvokeViaExecuteAsync()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("CustomAwaitableOfValueTypeAsync");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[] { 123, 456 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(int), executor.AsyncResultType);
+            Assert.NotNull(result);
+            Assert.IsType(typeof(int), result);
+            Assert.Equal(579, (int)result);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningAwaitableOfVoidType_CanInvokeViaExecuteAsync()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("VoidValueMethodAsync");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[] { 123 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(void), executor.AsyncResultType);
+            Assert.Null(result);
+        }
+        
+        [Fact]
+        public async void TargetMethodReturningAwaitableWithICriticalNotifyCompletion_UsesUnsafeOnCompleted()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("CustomAwaitableWithICriticalNotifyCompletion");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[0]);
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(string), executor.AsyncResultType);
+            Assert.Equal("Used UnsafeOnCompleted", (string)result);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningAwaitableWithoutICriticalNotifyCompletion_UsesOnCompleted()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("CustomAwaitableWithoutICriticalNotifyCompletion");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[0]);
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(string), executor.AsyncResultType);
+            Assert.Equal("Used OnCompleted", (string)result);
+        }
+        
+        [Fact]
+        public async void TargetMethodReturningValueTaskOfValueType_CanBeInvokedViaExecute()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("ValueTaskOfValueType");
+
+            // Act
+            var result = await (ValueTask<int>)executor.Execute(_targetObject, new object[] { 123 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(int), executor.AsyncResultType);
+            Assert.Equal(123, result);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningValueTaskOfReferenceType_CanBeInvokedViaExecute()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("ValueTaskOfReferenceType");
+
+            // Act
+            var result = await (ValueTask<string>)executor.Execute(_targetObject, new object[] { "test result" });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(string), executor.AsyncResultType);
+            Assert.Equal("test result", result);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningValueTaskOfValueType_CanBeInvokedViaExecuteAsync()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("ValueTaskOfValueType");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[] { 123 });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(int), executor.AsyncResultType);
+            Assert.NotNull(result);
+            Assert.Equal(123, (int)result);
+        }
+
+        [Fact]
+        public async void TargetMethodReturningValueTaskOfReferenceType_CanBeInvokedViaExecuteAsync()
+        {
+            // Arrange
+            var executor = GetExecutorForMethod("ValueTaskOfReferenceType");
+
+            // Act
+            var result = await executor.ExecuteAsync(_targetObject, new object[] { "test result" });
+
+            // Assert
+            Assert.True(executor.IsMethodAsync);
+            Assert.Same(typeof(string), executor.AsyncResultType);
+            Assert.Equal("test result", result);
+        }
+
+        private ObjectMethodExecutor GetExecutorForMethod(string methodName)
+        {
+            var method = typeof(TestObject).GetMethod(methodName);
+            return ObjectMethodExecutor.Create(method, targetTypeInfo);
+        }
+
+        private ObjectMethodExecutor GetExecutorForMethod(string methodName, object[] parameterDefaultValues)
+        {
+            var method = typeof(TestObject).GetMethod(methodName);
+            return ObjectMethodExecutor.Create(method, targetTypeInfo, parameterDefaultValues);
+        }
+
+        public class TestObject
+        {
+            public string value;
+            public int ValueMethod(int i, int j)
+            {
+                return i + j;
+            }
+
+            public void VoidValueMethod(int i)
+            {
+
+            }
+
+            public TestObject ValueMethodWithReturnType(int i)
+            {
+                return new TestObject() { value = "Hello" }; ;
+            }
+
+            public TestObject ValueMethodWithReturnTypeThrowsException(TestObject i)
+            {
+                throw new NotImplementedException("Not Implemented Exception");
+            }
+
+            public TestObject ValueMethodUpdateValue(TestObject parameter)
+            {
+                parameter.value = "HelloWorld";
+                return parameter;
+            }
+
+            public Task<int> ValueMethodAsync(int i, int j)
+            {
+                return Task.FromResult<int>(i + j);
+            }
+
+            public async Task VoidValueMethodAsync(int i)
+            {
+                await ValueMethodAsync(3, 4);
+            }
+            public Task<TestObject> ValueMethodWithReturnTypeAsync(int i)
+            {
+                return Task.FromResult<TestObject>(new TestObject() { value = "Hello" });
+            }
+
+            public async Task ValueMethodWithReturnVoidThrowsExceptionAsync(TestObject i)
+            {
+                await Task.CompletedTask;
+                throw new NotImplementedException("Not Implemented Exception");
+            }
+
+            public async Task<TestObject> ValueMethodWithReturnTypeThrowsExceptionAsync(TestObject i)
+            {
+                await Task.CompletedTask;
+                throw new NotImplementedException("Not Implemented Exception");
+            }
+
+            public Task<TestObject> ValueMethodUpdateValueAsync(TestObject parameter)
+            {
+                parameter.value = "HelloWorld";
+                return Task.FromResult<TestObject>(parameter);
+            }
+
+            public TestAwaitable<TestObject> CustomAwaitableOfReferenceTypeAsync(
+                string input1,
+                int input2)
+            {
+                return new TestAwaitable<TestObject>(new TestObject
+                {
+                    value = $"{input1} {input2}"
+                });
+            }
+
+            public TestAwaitable<int> CustomAwaitableOfValueTypeAsync(
+                int input1,
+                int input2)
+            {
+                return new TestAwaitable<int>(input1 + input2);
+            }
+
+            public TestAwaitableWithICriticalNotifyCompletion CustomAwaitableWithICriticalNotifyCompletion()
+            {
+                return new TestAwaitableWithICriticalNotifyCompletion();
+            }
+
+            public TestAwaitableWithoutICriticalNotifyCompletion CustomAwaitableWithoutICriticalNotifyCompletion()
+            {
+                return new TestAwaitableWithoutICriticalNotifyCompletion();
+            }
+            
+            public ValueTask<int> ValueTaskOfValueType(int result)
+            {
+                return new ValueTask<int>(result);
+            }
+
+            public ValueTask<string> ValueTaskOfReferenceType(string result)
+            {
+                return new ValueTask<string>(result);
+            }
+
+            public void MethodWithMultipleParameters(int valueTypeParam, string referenceTypeParam)
+            {
+            }
+        }
+
+        public class TestAwaitable<T>
+        {
+            private T _result;
+            private bool _isCompleted;
+            private List<Action> _onCompletedCallbacks = new List<Action>();
+
+            public TestAwaitable(T result)
+            {
+                _result = result;
+
+                // Simulate a brief delay before completion
+                ThreadPool.QueueUserWorkItem(_ =>
+                {
+                    Thread.Sleep(100);
+                    SetCompleted();
+                });
+            }
+
+            private void SetCompleted()
+            {
+                _isCompleted = true;
+
+                foreach (var callback in _onCompletedCallbacks)
+                {
+                    callback();
+                }
+            }
+
+            public TestAwaiter GetAwaiter()
+            {
+                return new TestAwaiter(this);
+            }
+
+            public struct TestAwaiter : INotifyCompletion
+            {
+                private TestAwaitable<T> _owner;
+
+                public TestAwaiter(TestAwaitable<T> owner) : this()
+                {
+                    _owner = owner;
+                }
+
+                public bool IsCompleted => _owner._isCompleted;
+
+                public void OnCompleted(Action continuation)
+                {
+                    if (_owner._isCompleted)
+                    {
+                        continuation();
+                    }
+                    else
+                    {
+                        _owner._onCompletedCallbacks.Add(continuation);
+                    }
+                }
+
+                public T GetResult()
+                {
+                    return _owner._result;
+                }
+            }
+        }
+
+        public class TestAwaitableWithICriticalNotifyCompletion
+        {
+            public TestAwaiterWithICriticalNotifyCompletion GetAwaiter()
+                => new TestAwaiterWithICriticalNotifyCompletion();
+        }
+
+        public class TestAwaitableWithoutICriticalNotifyCompletion
+        {
+            public TestAwaiterWithoutICriticalNotifyCompletion GetAwaiter()
+                => new TestAwaiterWithoutICriticalNotifyCompletion();
+        }
+
+        public class TestAwaiterWithICriticalNotifyCompletion
+            : CompletionTrackingAwaiterBase, ICriticalNotifyCompletion
+        {
+        }
+
+        public class TestAwaiterWithoutICriticalNotifyCompletion
+            : CompletionTrackingAwaiterBase, INotifyCompletion
+        {
+        }
+
+        public class CompletionTrackingAwaiterBase
+        {
+            private string _result;
+
+            public bool IsCompleted { get; private set; }
+
+            public string GetResult() => _result;
+
+            public void OnCompleted(Action continuation)
+            {
+                _result = "Used OnCompleted";
+                IsCompleted = true;
+                continuation();
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                _result = "Used UnsafeOnCompleted";
+                IsCompleted = true;
+                continuation();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a generalised version of MVC's `ObjectMethodExecutor` that can be used by MVC, SignalR, and possibly others, as per conversations for MVC issues 5570 and 6040.

It's generalised in the sense that:

 * It supports arbitrary awaitables, not just `Task`/`Task<T>`
 * It isn't coupled to MVC-specific concepts such as `IActionResult`

In a future pull request, I'll also extend it to support `FSharpAsync<T>`. Code making use of this package won't have to make any changes to obtain support for that.

**Note to reviewers:** When reviewing, bear in mind that much of the code here is unchanged from MVC's [`ObjectMethodExecutor`](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs) and its [tests](https://github.com/aspnet/Mvc/blob/dev/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTest.cs). To focus on what's new, please see the commits after the first one.