### PR TITLE
Pin CoreFX version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-preview1-*</AspNetCoreVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxCompilerServicesVersion>4.4.0-preview1-*</CoreFxCompilerServicesVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>

--- a/src/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.csproj
+++ b/src/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.csproj
@@ -16,7 +16,7 @@ Microsoft.Extensions.Primitives.StringSegment</Description>
 
   <ItemGroup>
     <Compile Include="..\..\shared\Microsoft.Extensions.HashCodeCombiner.Sources\**\*.cs" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0-*"/>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(CoreFxCompilerServicesVersion)"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I think this is blocking building runtime package store on the rel/2.0.0-preview1 branch on the CI.

```
\NuGet.targets(97,5): error : Unable to resolve 'System.Runtime.CompilerServices.Unsafe (>= 4.4.0-preview2-25225-02)' for '.NETStandard,Version=v1.3'.
```