### PR TITLE
In ObjectMethodExecutor, add FSharpAsync support

### DIFF
--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/AwaitableInfo.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/AwaitableInfo.cs
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal struct AwaitableInfo
+    {
+        public Type AwaiterType { get; }
+        public PropertyInfo AwaiterIsCompletedProperty { get; }
+        public MethodInfo AwaiterGetResultMethod { get; }
+        public MethodInfo AwaiterOnCompletedMethod { get; }
+        public MethodInfo AwaiterUnsafeOnCompletedMethod { get; }
+        public Type ResultType { get; }
+        public MethodInfo GetAwaiterMethod { get; }
+
+        public AwaitableInfo(
+            Type awaiterType,
+            PropertyInfo awaiterIsCompletedProperty,
+            MethodInfo awaiterGetResultMethod,
+            MethodInfo awaiterOnCompletedMethod,
+            MethodInfo awaiterUnsafeOnCompletedMethod,
+            Type resultType,
+            MethodInfo getAwaiterMethod)
+        {
+            AwaiterType = awaiterType;
+            AwaiterIsCompletedProperty = awaiterIsCompletedProperty;
+            AwaiterGetResultMethod = awaiterGetResultMethod;
+            AwaiterOnCompletedMethod = awaiterOnCompletedMethod;
+            AwaiterUnsafeOnCompletedMethod = awaiterUnsafeOnCompletedMethod;
+            ResultType = resultType;
+            GetAwaiterMethod = getAwaiterMethod;
+        }
+
+        public static bool IsTypeAwaitable(Type type, out AwaitableInfo awaitableInfo)
+        {
+            // Based on Roslyn code: http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ISymbolExtensions.cs,db4d48ba694b9347
+
+            // Awaitable must have method matching "object GetAwaiter()"
+            var getAwaiterMethod = type.GetRuntimeMethods().FirstOrDefault(m =>
+                m.Name.Equals("GetAwaiter", StringComparison.OrdinalIgnoreCase)
+                && m.GetParameters().Length == 0
+                && m.ReturnType != null);
+            if (getAwaiterMethod == null)
+            {
+                awaitableInfo = default(AwaitableInfo);
+                return false;
+            }
+
+            var awaiterType = getAwaiterMethod.ReturnType;
+
+            // Awaiter must have property matching "bool IsCompleted { get; }"
+            var isCompletedProperty = awaiterType.GetRuntimeProperties().FirstOrDefault(p =>
+                p.Name.Equals("IsCompleted", StringComparison.OrdinalIgnoreCase)
+                && p.PropertyType == typeof(bool)
+                && p.GetMethod != null);
+            if (isCompletedProperty == null)
+            {
+                awaitableInfo = default(AwaitableInfo);
+                return false;
+            }
+
+            // Awaiter must implement INotifyCompletion
+            var awaiterInterfaces = awaiterType.GetInterfaces();
+            var implementsINotifyCompletion = awaiterInterfaces.Any(t => t == typeof(INotifyCompletion));
+            if (!implementsINotifyCompletion)
+            {
+                awaitableInfo = default(AwaitableInfo);
+                return false;
+            }
+
+            // INotifyCompletion supplies a method matching "void OnCompleted(Action action)"
+            var iNotifyCompletionMap = awaiterType
+                .GetTypeInfo()
+                .GetRuntimeInterfaceMap(typeof(INotifyCompletion));
+            var onCompletedMethod = iNotifyCompletionMap.InterfaceMethods.Single(m =>
+                m.Name.Equals("OnCompleted", StringComparison.OrdinalIgnoreCase)
+                && m.ReturnType == typeof(void)
+                && m.GetParameters().Length == 1
+                && m.GetParameters()[0].ParameterType == typeof(Action));
+
+            // Awaiter optionally implements ICriticalNotifyCompletion
+            var implementsICriticalNotifyCompletion = awaiterInterfaces.Any(t => t == typeof(ICriticalNotifyCompletion));
+            MethodInfo unsafeOnCompletedMethod;
+            if (implementsICriticalNotifyCompletion)
+            {
+                // ICriticalNotifyCompletion supplies a method matching "void UnsafeOnCompleted(Action action)"
+                var iCriticalNotifyCompletionMap = awaiterType
+                    .GetTypeInfo()
+                    .GetRuntimeInterfaceMap(typeof(ICriticalNotifyCompletion));
+                unsafeOnCompletedMethod = iCriticalNotifyCompletionMap.InterfaceMethods.Single(m =>
+                    m.Name.Equals("UnsafeOnCompleted", StringComparison.OrdinalIgnoreCase)
+                    && m.ReturnType == typeof(void)
+                    && m.GetParameters().Length == 1
+                    && m.GetParameters()[0].ParameterType == typeof(Action));
+            }
+            else
+            {
+                unsafeOnCompletedMethod = null;
+            }
+
+            // Awaiter must have method matching "void GetResult" or "T GetResult()"
+            var getResultMethod = awaiterType.GetRuntimeMethods().FirstOrDefault(m =>
+                m.Name.Equals("GetResult")
+                && m.GetParameters().Length == 0);
+            if (getResultMethod == null)
+            {
+                awaitableInfo = default(AwaitableInfo);
+                return false;
+            }
+
+            awaitableInfo = new AwaitableInfo(
+                awaiterType,
+                isCompletedProperty,
+                getResultMethod,
+                onCompletedMethod,
+                unsafeOnCompletedMethod,
+                getResultMethod.ReturnType,
+                getAwaiterMethod);
+            return true;
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/CoercedAwaitableInfo.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/CoercedAwaitableInfo.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal struct CoercedAwaitableInfo
+    {
+        public AwaitableInfo AwaitableInfo { get; }
+        public Expression CoercerExpression { get; }
+        public Type CoercerResultType { get; }
+        public bool RequiresCoercion => CoercerExpression != null;
+
+        public CoercedAwaitableInfo(AwaitableInfo awaitableInfo)
+        {
+            AwaitableInfo = awaitableInfo;
+            CoercerExpression = null;
+            CoercerResultType = null;
+        }
+
+        public CoercedAwaitableInfo(Expression coercerExpression, Type coercerResultType, AwaitableInfo coercedAwaitableInfo)
+        {
+            CoercerExpression = coercerExpression;
+            CoercerResultType = coercerResultType;
+            AwaitableInfo = coercedAwaitableInfo;
+        }
+
+        public static bool IsTypeAwaitable(Type type, out CoercedAwaitableInfo info)
+        {
+            if (AwaitableInfo.IsTypeAwaitable(type, out var directlyAwaitableInfo))
+            {
+                info = new CoercedAwaitableInfo(directlyAwaitableInfo);
+                return true;
+            }
+
+            // It's not directly awaitable, but maybe we can coerce it.
+            // Currently we support coercing FSharpAsync<T>.
+            if (ObjectMethodExecutorFSharpSupport.TryBuildCoercerFromFSharpAsyncToAwaitable(type,
+                out var coercerExpression,
+                out var coercerResultType))
+            {
+                if (AwaitableInfo.IsTypeAwaitable(coercerResultType, out var coercedAwaitableInfo))
+                {
+                    info = new CoercedAwaitableInfo(coercerExpression, coercerResultType, coercedAwaitableInfo);
+                    return true;
+                }
+            }
+
+            info = default(CoercedAwaitableInfo);
+            return false;
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutor.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutor.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Internal
 {
@@ -38,19 +36,10 @@ namespace Microsoft.Extensions.Internal
             TargetTypeInfo = targetTypeInfo;
             MethodReturnType = methodInfo.ReturnType;
 
-            var isAwaitable = IsAwaitableDirectlyOrViaCoercion(MethodReturnType,
-                out var coerceToAwaitableExpression,
-                out var coerceToAwaitableType,
-                out var getAwaiterMethod,
-                out var awaiterType,
-                out var awaiterResultType,
-                out var awaiterIsCompletedProperty,
-                out var awaiterGetResultMethod,
-                out var awaiterOnCompletedMethod,
-                out var awaiterUnsafeOnCompletedMethod);
+            var isAwaitable = CoercedAwaitableInfo.IsTypeAwaitable(MethodReturnType, out var coercedAwaitableInfo);
 
             IsMethodAsync = isAwaitable;
-            AsyncResultType = isAwaitable ? awaiterResultType : null;
+            AsyncResultType = isAwaitable ? coercedAwaitableInfo.AwaitableInfo.ResultType : null;
 
             // Upstream code may prefer to use the sync-executor even for async methods, because if it knows
             // that the result is a specific Task<T> where T is known, then it can directly cast to that type
@@ -59,18 +48,7 @@ namespace Microsoft.Extensions.Internal
 
             if (IsMethodAsync)
             {
-                _executorAsync = GetExecutorAsync(
-                    methodInfo,
-                    targetTypeInfo,
-                    coerceToAwaitableExpression,
-                    coerceToAwaitableType,
-                    getAwaiterMethod,
-                    awaiterType,
-                    awaiterResultType,
-                    awaiterIsCompletedProperty,
-                    awaiterGetResultMethod,
-                    awaiterOnCompletedMethod,
-                    awaiterUnsafeOnCompletedMethod);
+                _executorAsync = GetExecutorAsync(methodInfo, targetTypeInfo, coercedAwaitableInfo);
             }
 
             _parameterDefaultValues = parameterDefaultValues;
@@ -222,15 +200,7 @@ namespace Microsoft.Extensions.Internal
         private static MethodExecutorAsync GetExecutorAsync(
             MethodInfo methodInfo,
             TypeInfo targetTypeInfo,
-            Expression coerceToAwaitableExpression,
-            Type coerceToAwaitableType,
-            MethodInfo getAwaiterMethod,
-            Type awaiterType,
-            Type awaiterResultType,
-            PropertyInfo awaiterIsCompletedProperty,
-            MethodInfo awaiterGetResultMethod,
-            MethodInfo awaiterOnCompletedMethod,
-            MethodInfo awaiterUnsafeOnCompletedMethod)
+            CoercedAwaitableInfo coercedAwaitableInfo)
         {
             // Parameters to executor
             var targetParameter = Expression.Parameter(typeof(object), "target");
@@ -261,12 +231,13 @@ namespace Microsoft.Extensions.Internal
             // var getAwaiterFunc = (object awaitable) =>
             //     (object)((CustomAwaitableType)awaitable).GetAwaiter();
             var customAwaitableParam = Expression.Parameter(typeof(object), "awaitable");
-            var postCoercionMethodReturnType = coerceToAwaitableType ?? methodInfo.ReturnType;
+            var awaitableInfo = coercedAwaitableInfo.AwaitableInfo;
+            var postCoercionMethodReturnType = coercedAwaitableInfo.CoercerResultType ?? methodInfo.ReturnType;
             var getAwaiterFunc = Expression.Lambda<Func<object, object>>(
                 Expression.Convert(
                     Expression.Call(
                         Expression.Convert(customAwaitableParam, postCoercionMethodReturnType),
-                        getAwaiterMethod),
+                        awaitableInfo.GetAwaiterMethod),
                     typeof(object)),
                 customAwaitableParam).Compile();
 
@@ -275,13 +246,13 @@ namespace Microsoft.Extensions.Internal
             var isCompletedParam = Expression.Parameter(typeof(object), "awaiter");
             var isCompletedFunc = Expression.Lambda<Func<object, bool>>(
                 Expression.MakeMemberAccess(
-                    Expression.Convert(isCompletedParam, awaiterType),
-                    awaiterIsCompletedProperty),
+                    Expression.Convert(isCompletedParam, awaitableInfo.AwaiterType),
+                    awaitableInfo.AwaiterIsCompletedProperty),
                 isCompletedParam).Compile();
 
             var getResultParam = Expression.Parameter(typeof(object), "awaiter");
             Func<object, object> getResultFunc;
-            if (awaiterResultType == typeof(void))
+            if (awaitableInfo.ResultType == typeof(void))
             {
                 // var getResultFunc = (object awaiter) =>
                 // {
@@ -291,8 +262,8 @@ namespace Microsoft.Extensions.Internal
                 getResultFunc = Expression.Lambda<Func<object, object>>(
                     Expression.Block(
                         Expression.Call(
-                            Expression.Convert(getResultParam, awaiterType),
-                            awaiterGetResultMethod),
+                            Expression.Convert(getResultParam, awaitableInfo.AwaiterType),
+                            awaitableInfo.AwaiterGetResultMethod),
                         Expression.Constant(null)
                     ),
                     getResultParam).Compile();
@@ -304,8 +275,8 @@ namespace Microsoft.Extensions.Internal
                 getResultFunc = Expression.Lambda<Func<object, object>>(
                     Expression.Convert(
                         Expression.Call(
-                            Expression.Convert(getResultParam, awaiterType),
-                            awaiterGetResultMethod),
+                            Expression.Convert(getResultParam, awaitableInfo.AwaiterType),
+                            awaitableInfo.AwaiterGetResultMethod),
                         typeof(object)),
                     getResultParam).Compile();
             }
@@ -317,14 +288,14 @@ namespace Microsoft.Extensions.Internal
             var onCompletedParam2 = Expression.Parameter(typeof(Action), "continuation");
             var onCompletedFunc = Expression.Lambda<Action<object, Action>>(
                 Expression.Call(
-                    Expression.Convert(onCompletedParam1, awaiterType),
-                    awaiterOnCompletedMethod,
+                    Expression.Convert(onCompletedParam1, awaitableInfo.AwaiterType),
+                    awaitableInfo.AwaiterOnCompletedMethod,
                     onCompletedParam2),
                 onCompletedParam1,
                 onCompletedParam2).Compile();
 
             Action<object, Action> unsafeOnCompletedFunc = null;
-            if (awaiterUnsafeOnCompletedMethod != null)
+            if (awaitableInfo.AwaiterUnsafeOnCompletedMethod != null)
             {
                 // var unsafeOnCompletedFunc = (object awaiter, Action continuation) => {
                 //     ((CustomAwaiterType)awaiter).UnsafeOnCompleted(continuation);
@@ -333,8 +304,8 @@ namespace Microsoft.Extensions.Internal
                 var unsafeOnCompletedParam2 = Expression.Parameter(typeof(Action), "continuation");
                 unsafeOnCompletedFunc = Expression.Lambda<Action<object, Action>>(
                     Expression.Call(
-                        Expression.Convert(unsafeOnCompletedParam1, awaiterType),
-                        awaiterUnsafeOnCompletedMethod,
+                        Expression.Convert(unsafeOnCompletedParam1, awaitableInfo.AwaiterType),
+                        awaitableInfo.AwaiterUnsafeOnCompletedMethod,
                         unsafeOnCompletedParam2),
                     unsafeOnCompletedParam1,
                     unsafeOnCompletedParam2).Compile();
@@ -342,8 +313,8 @@ namespace Microsoft.Extensions.Internal
 
             // If we need to pass the method call result through a coercer function to get an
             // awaitable, then do so.
-            var coercedMethodCall = coerceToAwaitableExpression != null
-                ? Expression.Invoke(coerceToAwaitableExpression, methodCall)
+            var coercedMethodCall = coercedAwaitableInfo.RequiresCoercion
+                ? Expression.Invoke(coercedAwaitableInfo.CoercerExpression, methodCall)
                 : (Expression)methodCall;
 
             // return new ObjectMethodExecutorAwaitable(
@@ -364,148 +335,6 @@ namespace Microsoft.Extensions.Internal
 
             var lambda = Expression.Lambda<MethodExecutorAsync>(returnValueExpression, targetParameter, parametersParameter);
             return lambda.Compile();
-        }
-
-        private static bool IsAwaitableDirectlyOrViaCoercion(
-            Type type,
-            out Expression coerceToAwaitableExpression,
-            out Type coerceToAwaitableType,
-            out MethodInfo getAwaiterMethod,
-            out Type awaiterType,
-            out Type returnType,
-            out PropertyInfo isCompletedProperty,
-            out MethodInfo getResultMethod,
-            out MethodInfo onCompletedMethod,
-            out MethodInfo unsafeOnCompletedMethod)
-        {
-            if (IsAwaitable(type,
-                out getAwaiterMethod,
-                out awaiterType,
-                out returnType,
-                out isCompletedProperty,
-                out getResultMethod,
-                out onCompletedMethod,
-                out unsafeOnCompletedMethod))
-            {
-                coerceToAwaitableExpression = null;
-                coerceToAwaitableType = null;
-                return true;
-            }
-
-            // It's not directly awaitable, but maybe we can coerce it.
-            // Currently we support coercing FSharpAsync<T>.
-            if (ObjectMethodExecutorFSharpSupport.TryBuildCoercerFromFSharpAsyncToAwaitable(type,
-                out coerceToAwaitableExpression,
-                out coerceToAwaitableType))
-            {
-                return IsAwaitable(coerceToAwaitableType,
-                    out getAwaiterMethod,
-                    out awaiterType,
-                    out returnType,
-                    out isCompletedProperty,
-                    out getResultMethod,
-                    out onCompletedMethod,
-                    out unsafeOnCompletedMethod);
-            }
-
-            return false;
-        }
-
-        private static bool IsAwaitable(
-            Type type,
-            out MethodInfo getAwaiterMethod,
-            out Type awaiterType,
-            out Type returnType,
-            out PropertyInfo isCompletedProperty,
-            out MethodInfo getResultMethod,
-            out MethodInfo onCompletedMethod,
-            out MethodInfo unsafeOnCompletedMethod)
-        {
-            // Based on Roslyn code: http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ISymbolExtensions.cs,db4d48ba694b9347
-
-            // Awaitable must have method matching "object GetAwaiter()"
-            getAwaiterMethod = type.GetRuntimeMethods().FirstOrDefault(m => 
-                m.Name.Equals("GetAwaiter", StringComparison.OrdinalIgnoreCase)
-                && m.GetParameters().Length == 0
-                && m.ReturnType != null);
-            if (getAwaiterMethod == null)
-            {
-                awaiterType = null;
-                isCompletedProperty = null;
-                onCompletedMethod = null;
-                unsafeOnCompletedMethod = null;
-                getResultMethod = null;
-                returnType = null;
-                return false;
-            }
-
-            awaiterType = getAwaiterMethod.ReturnType;
-
-            // Awaiter must have property matching "bool IsCompleted { get; }"
-            isCompletedProperty = awaiterType.GetRuntimeProperties().FirstOrDefault(p =>
-                p.Name.Equals("IsCompleted", StringComparison.OrdinalIgnoreCase)
-                && p.PropertyType == typeof(bool)
-                && p.GetMethod != null);
-            if (isCompletedProperty == null)
-            {
-                onCompletedMethod = null;
-                unsafeOnCompletedMethod = null;
-                getResultMethod = null;
-                returnType = null;
-                return false;
-            }
-
-            // Awaiter must implement INotifyCompletion
-            var awaiterInterfaces = awaiterType.GetInterfaces();
-            var implementsINotifyCompletion = awaiterInterfaces.Any(t => t == typeof(INotifyCompletion));
-            if (implementsINotifyCompletion)
-            {
-                // INotifyCompletion supplies a method matching "void OnCompleted(Action action)"
-                var interfaceMap = awaiterType.GetTypeInfo().GetRuntimeInterfaceMap(typeof(INotifyCompletion));
-                onCompletedMethod = interfaceMap.InterfaceMethods.Single(m =>
-                    m.Name.Equals("OnCompleted", StringComparison.OrdinalIgnoreCase)
-                    && m.ReturnType == typeof(void)
-                    && m.GetParameters().Length == 1
-                    && m.GetParameters()[0].ParameterType == typeof(Action));
-            }
-            else
-            {
-                onCompletedMethod = null;
-                unsafeOnCompletedMethod = null;
-                getResultMethod = null;
-                returnType = null;
-                return false;
-            }
-
-            // Awaiter optionally implements ICriticalNotifyCompletion
-            var implementsICriticalNotifyCompletion = awaiterInterfaces.Any(t => t == typeof(ICriticalNotifyCompletion));
-            if (implementsICriticalNotifyCompletion)
-            {
-                // ICriticalNotifyCompletion supplies a method matching "void UnsafeOnCompleted(Action action)"
-                var interfaceMap = awaiterType.GetTypeInfo().GetRuntimeInterfaceMap(typeof(ICriticalNotifyCompletion));
-                unsafeOnCompletedMethod = interfaceMap.InterfaceMethods.Single(m =>
-                    m.Name.Equals("UnsafeOnCompleted", StringComparison.OrdinalIgnoreCase)
-                    && m.ReturnType == typeof(void)
-                    && m.GetParameters().Length == 1
-                    && m.GetParameters()[0].ParameterType == typeof(Action));
-            }
-            else
-            {
-                unsafeOnCompletedMethod = null;
-            }
-
-            // Awaiter must have method matching "void GetResult" or "T GetResult()"
-            getResultMethod = awaiterType.GetRuntimeMethods().FirstOrDefault(m =>
-                m.Name.Equals("GetResult")
-                && m.GetParameters().Length == 0);
-            if (getResultMethod == null)
-            {
-                returnType = null;
-                return false;
-            }
-
-            returnType = getResultMethod.ReturnType;
-            return true;
         }
     }
 }

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutor.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutor.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Extensions.Internal
                 : (Expression)methodCall;
 
             // return new ObjectMethodExecutorAwaitable(
-            //     coercedMethodCall,
+            //     (object)coercedMethodCall,
             //     getAwaiterFunc,
             //     isCompletedFunc,
             //     getResultFunc,

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutorFSharpSupport.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutorFSharpSupport.cs
@@ -1,0 +1,150 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Internal
+{
+    /// <summary>
+    /// Helper for detecting whether a given type is FSharpAsync`1, and if so, supplying
+    /// an <see cref="Expression"/> for mapping instances of that type to a C# awaitable.
+    /// </summary>
+    /// <remarks>
+    /// The main design goal here is to avoid taking a compile-time dependency on
+    /// FSharp.Core.dll, because non-F# applications wouldn't use it. So all the references
+    /// to FSharp types have to be constructed dynamically at runtime.
+    /// </remarks>
+    internal static class ObjectMethodExecutorFSharpSupport
+    {
+        private static object _fsharpValuesCacheLock = new object();
+        private static Assembly _fsharpCoreAssembly;
+        private static MethodInfo _fsharpAsyncStartAsTaskGenericMethod;
+        private static PropertyInfo _fsharpOptionOfTaskCreationOptionsNoneProperty;
+        private static PropertyInfo _fsharpOptionOfCancellationTokenNoneProperty;
+
+        public static bool TryBuildCoercerFromFSharpAsyncToAwaitable(
+            Type possibleFSharpAsyncType,
+            out Expression coerceToAwaitableExpression,
+            out Type awaitableType)
+        {
+            var methodReturnGenericType = possibleFSharpAsyncType.IsGenericType
+                ? possibleFSharpAsyncType.GetGenericTypeDefinition()
+                : null;
+
+            if (!IsFSharpAsyncOpenGenericType(methodReturnGenericType))
+            {
+                coerceToAwaitableExpression = null;
+                awaitableType = null;
+                return false;
+            }
+
+            var awaiterResultType = possibleFSharpAsyncType.GetGenericArguments().Single();
+            awaitableType = typeof(Task<>).MakeGenericType(awaiterResultType);
+
+            // coerceToAwaitableExpression = (object fsharpAsync) =>
+            // {
+            //     return (object)FSharpAsync.StartAsTask<TResult>(
+            //         (Microsoft.FSharp.Control.FSharpAsync<TResult>)fsharpAsync,
+            //         FSharpOption<TaskCreationOptions>.None,
+            //         FSharpOption<CancellationToken>.None);
+            // };
+            var startAsTaskClosedMethod = _fsharpAsyncStartAsTaskGenericMethod
+                .MakeGenericMethod(awaiterResultType);
+            var coerceToAwaitableParam = Expression.Parameter(typeof(object));
+            coerceToAwaitableExpression = Expression.Lambda(
+                Expression.Convert(
+                    Expression.Call(
+                        startAsTaskClosedMethod,
+                        Expression.Convert(coerceToAwaitableParam, possibleFSharpAsyncType),
+                        Expression.MakeMemberAccess(null, _fsharpOptionOfTaskCreationOptionsNoneProperty),
+                        Expression.MakeMemberAccess(null, _fsharpOptionOfCancellationTokenNoneProperty)),
+                    typeof(object)),
+                coerceToAwaitableParam);
+
+            return true;
+        }
+
+        private static bool IsFSharpAsyncOpenGenericType(Type possibleFSharpAsyncGenericType)
+        {
+            if (possibleFSharpAsyncGenericType?.FullName != "Microsoft.FSharp.Control.FSharpAsync`1")
+            {
+                return false;
+            }
+
+            lock (_fsharpValuesCacheLock)
+            {
+                if (_fsharpCoreAssembly != null)
+                {
+                    // Since we've already found the real FSharpAsync.Core assembly, we just have
+                    // to check that the supplied FSharpAsync`1 type is the one from that assembly.
+                    return possibleFSharpAsyncGenericType.Assembly == _fsharpCoreAssembly;
+                }
+                else
+                {
+                    // We'll keep trying to find the FSharp types/values each time any type called
+                    // FSharpAsync`1 is supplied.
+                    return TryPopulateFSharpValueCaches(possibleFSharpAsyncGenericType);
+                }
+            }
+        }
+
+        private static bool TryPopulateFSharpValueCaches(Type possibleFSharpAsyncGenericType)
+        {
+            var assembly = possibleFSharpAsyncGenericType.Assembly;
+            var fsharpOptionType = assembly.GetType("Microsoft.FSharp.Core.FSharpOption`1");
+            var fsharpAsyncType = assembly.GetType("Microsoft.FSharp.Control.FSharpAsync");
+
+            if (fsharpOptionType == null || fsharpAsyncType == null)
+            {
+                return false;
+            }
+
+            // Get a reference to FSharpOption<TaskCreationOptions>.None
+            var fsharpOptionOfTaskCreationOptionsType = fsharpOptionType
+                .MakeGenericType(typeof(TaskCreationOptions));
+            _fsharpOptionOfTaskCreationOptionsNoneProperty = fsharpOptionOfTaskCreationOptionsType
+                .GetTypeInfo()
+                .GetRuntimeProperty("None");
+
+            // Get a reference to FSharpOption<CancellationToken>.None
+            var fsharpOptionOfCancellationTokenType = fsharpOptionType
+                .MakeGenericType(typeof(CancellationToken));
+            _fsharpOptionOfCancellationTokenNoneProperty = fsharpOptionOfCancellationTokenType
+                .GetTypeInfo()
+                .GetRuntimeProperty("None");
+
+            // Get a reference to FSharpAsync.StartAsTask<>
+            var fsharpAsyncMethods = fsharpAsyncType
+                .GetRuntimeMethods()
+                .Where(m => m.Name.Equals("StartAsTask", StringComparison.Ordinal));
+            foreach (var candidateMethodInfo in fsharpAsyncMethods)
+            {
+                var parameters = candidateMethodInfo.GetParameters();
+                if (parameters.Length == 3
+                    && TypesHaveSameIdentity(parameters[0].ParameterType, possibleFSharpAsyncGenericType)
+                    && parameters[1].ParameterType == fsharpOptionOfTaskCreationOptionsType
+                    && parameters[2].ParameterType == fsharpOptionOfCancellationTokenType)
+                {
+                    // This really does look like the correct method (and hence assembly).
+                    _fsharpAsyncStartAsTaskGenericMethod = candidateMethodInfo;
+                    _fsharpCoreAssembly = assembly;
+                    break;
+                }
+            }
+
+            return _fsharpCoreAssembly != null;
+        }
+
+        private static bool TypesHaveSameIdentity(Type type1, Type type2)
+        {
+            return type1.Assembly == type2.Assembly
+                && type1.Namespace == type2.Namespace
+                && type1.Name == type2.Name;
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutorFSharpSupport.cs
+++ b/shared/Microsoft.Extensions.ObjectMethodExecutor.Sources/ObjectMethodExecutorFSharpSupport.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Extensions.Internal
 
         private static bool IsFSharpAsyncOpenGenericType(Type possibleFSharpAsyncGenericType)
         {
-            if (possibleFSharpAsyncGenericType?.FullName != "Microsoft.FSharp.Control.FSharpAsync`1")
+            var typeFullName = possibleFSharpAsyncGenericType?.FullName;
+            if (!string.Equals(typeFullName, "Microsoft.FSharp.Control.FSharpAsync`1", StringComparison.Ordinal))
             {
                 return false;
             }
@@ -143,8 +144,8 @@ namespace Microsoft.Extensions.Internal
         private static bool TypesHaveSameIdentity(Type type1, Type type2)
         {
             return type1.Assembly == type2.Assembly
-                && type1.Namespace == type2.Namespace
-                && type1.Name == type2.Name;
+                && string.Equals(type1.Namespace, type2.Namespace, StringComparison.Ordinal)
+                && string.Equals(type1.Name, type2.Name, StringComparison.Ordinal);
         }
     }
 }

--- a/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
+++ b/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.1.17" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />


### PR DESCRIPTION
To cover MVC requirements, this extends `ObjectMethodExecutor` so it knows how to treat `FSharpAsync<T>` as async and coerce it to an awaitable so that the upstream code gets the correct async result value.