### PR TITLE
Update to test sdk 15.3.0 and xunit 2.3.0-beta2

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -623,10 +623,15 @@ Examples:
             }
         }
 
+        // disable inaccurate analyzer error https://github.com/xunit/xunit/issues/1274
+#pragma warning disable xUnit1010
+#pragma warning disable xUnit1011
         [Theory]
         [InlineData("-f:File1", "-f:File2")]
         [InlineData("--file:File1", "--file:File2")]
         [InlineData("--file", "File1", "--file", "File2")]
+#pragma warning restore xUnit1010
+#pragma warning restore xUnit1011
         public void ThrowsExceptionOnSingleValueOptionHavingTwoValues(params string[] inputOptions)
         {
             var app = new CommandLineApplication();

--- a/test/Microsoft.Extensions.Internal.Test/ObjectMethodExecutorTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ObjectMethodExecutorTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Internal
                 _targetObject,
                 new object[] { 10 });
             Assert.False(executor.IsMethodAsync);
-            Assert.Same(null, result);
+            Assert.Null(result);
         }
 
         [Fact]
@@ -182,7 +182,6 @@ namespace Microsoft.Extensions.Internal
             // Assert
             Assert.True(executor.IsMethodAsync);
             Assert.Same(typeof(int), executor.AsyncResultType);
-            Assert.NotNull(result);
             Assert.Equal(579, result);
         }
 

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(5);
             formatter.Append("123");
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.ToString());
-            Assert.Equal(exception.Message, "Entire reserved capacity was not used. Capacity: '5', written '3'.");
+            Assert.Equal("Entire reserved capacity was not used. Capacity: '5', written '3'.", exception.Message);
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             formatter.Append("123");
 
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Capacity = 5);
-            Assert.Equal(exception.Message, "Cannot change capacity after write started.");
+            Assert.Equal("Cannot change capacity after write started.", exception.Message);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Http.Tests.Internal
             var formatter = new InplaceStringBuilder(1);
 
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Append("123"));
-            Assert.Equal(exception.Message, "Not enough capacity to write '3' characters, only '1' left.");
+            Assert.Equal("Not enough capacity to write '3' characters, only '1' left.", exception.Message);
         }
     }
 }

--- a/test/Microsoft.Extensions.Primitives.Tests/StringTokenizerTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/StringTokenizerTest.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Extensions.Primitives
         [InlineData("a", new[] { "a" })]
         [InlineData("abc", new[] { "abc" })]
         [InlineData("a,b", new[] { "a", "b" })]
-        [InlineData("a,b", new[] { "a", "b" })]
         [InlineData("a,,b", new[] { "a", "", "b" })]
         [InlineData(",a,b", new[] { "", "a", "b" })]
         [InlineData(",,a,b", new[] { "", "", "a", "b" })]
@@ -45,7 +44,7 @@ namespace Microsoft.Extensions.Primitives
             // Assert
             Assert.Equal(expected, result);
         }
-        
+
         [Theory]
         [InlineData("", new[] { "" })]
         [InlineData("a", new[] { "a" })]


### PR DESCRIPTION
Xunit 2.3.0 includes lots of goodies, such warnings that identify duplicate InlineData and xunit.analyzers which correctly identified some issues in tests such as incorrectly ordering of args passed to `Assert.Equal(expected, actual)`.

Also, updates Microsoft.NET.Test.Sdk which includes dozens of fixes to testhost.