### PR TITLE
Use Process.MainModule to find the dotnet muxer

### DIFF
--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
@@ -38,20 +38,21 @@ namespace Microsoft.Extensions.CommandLineUtils
 
         private static string TryFindMuxerPath()
         {
-            var mainModule = Process.GetCurrentProcess().MainModule;
-            if (!string.IsNullOrEmpty(mainModule?.FileName) && File.Exists(mainModule.FileName))
-            {
-                return mainModule.FileName;
-            }
-
-            // if Process.MainModule is not available, fallback to trying to navigate to the muxer
-            // by using the location of the shared framework
-
             var fileName = MuxerName;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName += ".exe";
             }
+
+            var mainModule = Process.GetCurrentProcess().MainModule;
+            if (!string.IsNullOrEmpty(mainModule?.FileName)
+                && Path.GetFileName(mainModule.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return mainModule.FileName;
+            }
+
+            // if Process.MainModule is not available or it does not equal "dotnet(.exe)?", fallback to navigating to the muxer
+            // by using the location of the shared framework
 
             var fxDepsFile = AppContext.GetData("FX_DEPS_FILE") as string;
 

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
@@ -5,6 +5,7 @@
 #if !NET451 && !NET452 && !NET46 && !NET461
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -37,6 +38,15 @@ namespace Microsoft.Extensions.CommandLineUtils
 
         private static string TryFindMuxerPath()
         {
+            var mainModule = Process.GetCurrentProcess().MainModule;
+            if (!string.IsNullOrEmpty(mainModule?.FileName) && File.Exists(mainModule.FileName))
+            {
+                return mainModule.FileName;
+            }
+
+            // if Process.MainModule is not available, fallback to trying to navigate to the muxer
+            // by using the location of the shared framework
+
             var fileName = MuxerName;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/DotNetMuxerTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/DotNetMuxerTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             var muxerPath = DotNetMuxer.MuxerPath;
             Assert.NotNull(muxerPath);
             Assert.True(File.Exists(muxerPath), "The file did not exist");
+            Assert.True(Path.IsPathRooted(muxerPath), "The path should be rooted");
         }
     }
 }

--- a/test/Microsoft.Extensions.CommandLineUtils.Tests/DotNetMuxerTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Tests/DotNetMuxerTests.cs
@@ -3,6 +3,7 @@
 
 #if NETCOREAPP2_0
 using System.IO;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Microsoft.Extensions.CommandLineUtils
@@ -16,6 +17,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             Assert.NotNull(muxerPath);
             Assert.True(File.Exists(muxerPath), "The file did not exist");
             Assert.True(Path.IsPathRooted(muxerPath), "The path should be rooted");
+            Assert.Equal("dotnet", Path.GetFileNameWithoutExtension(muxerPath), ignoreCase: true);
         }
     }
 }


### PR DESCRIPTION
Per discussion on https://github.com/dotnet/core-setup/issues/2473, it appears Process.MainModule is a more accurate way to find the path to corehost.

Resolves issues related to multi-hive lookup and aspnet/dotnettools and aspnet/buildtools.