### PR TITLE
Add list packages and community forks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,43 @@
 Common
-===
-AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/snawy2a2vt0vd7dv/branch/dev?svg=true)](https://ci.appveyor.com/project/aspnetci/Common/branch/dev)
+======
 
-Travis:   [![Travis](https://travis-ci.org/aspnet/Common.svg?branch=dev)](https://travis-ci.org/aspnet/Common)
+[![Travis build status][travis-badge]](https://travis-ci.org/aspnet/Common/branches)
+[![AppVeyor build status][appveyor-badge]](https://ci.appveyor.com/project/aspnetci/Common/branch/dev)
+
+[travis-badge]: https://img.shields.io/travis/aspnet/Common.svg?label=travis-ci&branch=dev&style=flat-square
+[appveyor-badge]: https://img.shields.io/appveyor/ci/aspnetci/Common/dev.svg?label=appveyor&style=flat-square
 
 The Common repository includes projects containing commonly used primitives and utility types.
 
 This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://github.com/aspnet/home) repo.
+
+## Packages
+
+ Package name                            | Stable                                      | Nightly (`dev` branch)
+-----------------------------------------|---------------------------------------------|------------------------------------------
+`Microsoft.Extensions.ObjectPool`        | [![NuGet][obj-nuget-badge]][obj-nuget]      | [![MyGet][obj-myget-badge]][obj-myget]
+`Microsoft.Extensions.Primitives`        | [![NuGet][prim-nuget-badge]][prim-nuget]    | [![MyGet][prim-myget-badge]][prim-myget]
+`Microsoft.Extensions.CommandLineUtils`  | [![NuGet][cli-nuget-badge]][cli-nuget]      | Not under active development. See below.
+
+
+[obj-nuget]: https://www.nuget.org/packages/Microsoft.Extensions.ObjectPool/
+[obj-nuget-badge]: https://img.shields.io/nuget/v/Microsoft.Extensions.ObjectPool.svg?style=flat-square&label=nuget
+[obj-myget]: https://dotnet.myget.org/feed/aspnetcore-dev/package/nuget/Microsoft.Extensions.ObjectPool
+[obj-myget-badge]: https://img.shields.io/dotnet.myget/aspnetcore-dev/vpre/Microsoft.Extensions.ObjectPool.svg?style=flat-square&label=myget
+
+[prim-nuget]: https://www.nuget.org/packages/Microsoft.Extensions.Primitives/
+[prim-nuget-badge]: https://img.shields.io/nuget/v/Microsoft.Extensions.Primitives.svg?style=flat-square&label=nuget
+[prim-myget]: https://dotnet.myget.org/feed/aspnetcore-dev/package/nuget/Microsoft.Extensions.Primitives
+[prim-myget-badge]: https://img.shields.io/dotnet.myget/aspnetcore-dev/vpre/Microsoft.Extensions.Primitives.svg?style=flat-square&label=myget
+
+[cli-nuget]: https://www.nuget.org/packages/Microsoft.Extensions.CommandLineUtils/
+[cli-nuget-badge]: https://img.shields.io/nuget/v/Microsoft.Extensions.CommandLineUtils.svg?style=flat-square&label=nuget
+
+## Community forks
+
+#### [McMaster.Extensions.CommandLineUtils](https://github.com/natemcmaster/CommandLineUtils)
+
+This is a fork of Microsoft.Extensions.CommandLineUtils.
+
+ - GitHub: <https://github.com/natemcmaster/CommandLineUtils>
+ - NuGet: <https://www.nuget.org/packages/McMaster.Extensions.CommandLineUtils>


### PR DESCRIPTION
In response to the discontinuation of active dev work on CommandLineUtils (#257), I've decided to fork the command-line utils project here: https://github.com/natemcmaster/CommandLineUtils. This will be an outside of work project and does not have official sponsorship from the aspnet team. This project is also under the same Apache license: @Eilon let me know if I need to change any of the license documents or links this fork.