### PR TITLE
Fix arrays display in TypeNameHelper

### DIFF
--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -107,6 +108,20 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal("ulong", TypeNameHelper.GetTypeDisplayName(typeof(ulong)));
             Assert.Equal("ushort", TypeNameHelper.GetTypeDisplayName(typeof(ushort)));
         }
+
+        [Theory]
+        [InlineData("int[]", typeof(int[]))]
+        [InlineData("string[][]", typeof(string[][]))]
+        [InlineData("int[,]", typeof(int[,]))]
+        [InlineData("bool[,,,]", typeof(bool[,,,]))]
+        [InlineData("Microsoft.Extensions.Internal.TypeNameHelperTest+A[,][,,]", typeof(A[,][,,]))]
+        [InlineData("System.Collections.Generic.List<int[,][,,]>", typeof(List<int[,][,,]>))]
+        [InlineData("List<int[,,][,]>[,][,,]", typeof(List<int[,,][,]>[,][,,]), false)]
+        public void Can_pretty_print_array_name(string expected, Type type, bool fullName = true)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
+        }
+
         private class A { }
 
         private class B<T> { }


### PR DESCRIPTION
Fix for issue #216

It includes four cases:
- Simple array: 
`int[]`
- An array of arrays: 
`int[][]`
- Multi-dimensional array: 
`int[,,]` 
- An array of multi-dimensional arrays:
This case is a bit confusing, because `int[,][]` actually two-dimensional array of one-dimensional arrays and `typeof(int[,][]).ToString()` will return `"System.Int32[][,]"` (more details could be found [here](https://blogs.msdn.microsoft.com/ericlippert/2009/08/17/arrays-of-arrays/)). I've desided to preserve brackets order, so for `typeof(int[,][,,][,,,])` we will display: 
`typeof(int[,][,,][,,,])`