### PR TITLE
[WIP] Add method to get display name for MethodInfo

### DIFF
--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Extensions.Internal
 
         public static string GetMethodDisplayName(MethodBase method, bool fullTypeName = true)
         {
-            var sb = new StringBuilder();
-            ProcessMethodName(method, sb, fullTypeName);
-            return sb.ToString();
+            var builder = new StringBuilder();
+            ProcessMethod(builder, method, fullTypeName);
+            return builder.ToString();
         }
 
         private static void ProcessType(StringBuilder builder, Type type, NameFormatting nameFormatting)
@@ -145,38 +145,38 @@ namespace Microsoft.Extensions.Internal
             builder.Append('>');
         }
 
-        private static void ProcessMethodName(MethodBase method, StringBuilder sb, bool fullTypeName)
+        private static void ProcessMethod(StringBuilder builder, MethodBase method, bool fullTypeName)
         {            
             var nameFormatting = NameFormatFromBool(fullTypeName) | NameFormatting.GenericParameterName;
             var methodInfo = method as MethodInfo;
             if (methodInfo != null)
             {
-                ProcessType(sb, methodInfo.ReturnType, nameFormatting);
-                sb.Append(' ');
+                ProcessType(builder, methodInfo.ReturnType, nameFormatting);
+                builder.Append(' ');
             }
 
-            sb.Append(method.Name);
+            builder.Append(method.Name);
 
             if (method.IsGenericMethod)
             {
                 var genericArguments = method.GetGenericArguments();
-                sb.Append("<");
+                builder.Append('<');
 
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
-                    ProcessType(sb, genericArguments[i], nameFormatting);
+                    ProcessType(builder, genericArguments[i], nameFormatting);
                     if (i + 1 < genericArguments.Length)
                     {
-                        sb.Append(", ");
+                        builder.Append(", ");
                     }
                 }
 
-                sb.Append(">");
+                builder.Append('>');
             }
 
             var parameters = method.GetParameters();
 
-            sb.Append("(");
+            builder.Append('(');
             for (int i = 0; i < parameters.Length; i++)
             {
                 var parameter = parameters[i];
@@ -184,11 +184,11 @@ namespace Microsoft.Extensions.Internal
 
                 if (parameter.IsOut)
                 {
-                    sb.Append("out ");
+                    builder.Append("out ");
                 }
                 else if (type.IsByRef)
                 {
-                    sb.Append("ref ");
+                    builder.Append("ref ");
                 }
 
                 if (type.IsByRef)
@@ -196,18 +196,18 @@ namespace Microsoft.Extensions.Internal
                     type = type.GetElementType();
                 }
 
-                ProcessType(sb, type, nameFormatting);
-                sb.Append(" ");
-                sb.Append(parameter.Name);
+                ProcessType(builder, type, nameFormatting);
+                builder.Append(' ');
+                builder.Append(parameter.Name);
 
 
                 if (i + 1 < parameters.Length)
                 {
-                    sb.Append(", ");
+                    builder.Append(", ");
                 }
             }
 
-            sb.Append(")");
+            builder.Append(')');
         }
 
         [Flags]

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -170,44 +170,46 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
         }
 
-        public static IEnumerable<object[]> GetMethodInfos()
+        public static TheoryData GetMethodInfo()
         {
             var type = typeof(TypeWithMethodsForTest);
-            yield return new object[]
+            return new TheoryData<MethodBase, bool, string>
             {
-                ".ctor(ref double val)",
-                type.GetConstructors().Single()
-            };
-            yield return new object[]
-            {
-                "object Test1<T1, T2>(out int a, ref string b, object c)",
-                type.GetMethod(nameof(TypeWithMethodsForTest.Test1))
-            };
-            yield return new object[]
-            {
-                "TName Test2<TName>(TName t, Dictionary<TName, int> l)",
-                type.GetMethod(nameof(TypeWithMethodsForTest.Test2)),
-                false
-            };
-            yield return new object[]
-            {
-                "string Test2<string>(string t, System.Collections.Generic.Dictionary<string, int> l)",
-                type.GetMethod(nameof(TypeWithMethodsForTest.Test2)).MakeGenericMethod(typeof(string))
-            };
-            yield return new object[]
-            {
-                "bool Test3(bool f, float z, Microsoft.Extensions.Internal.TypeNameHelperTest+A[] p)",
-                type.GetMethod(nameof(TypeWithMethodsForTest.Test3))
-            };
+                { typeof(B<>).GetConstructors().Single(), true, ".ctor()" },
+                { typeof(B<int>).GetConstructors().Single(), true, ".ctor()" },
+                { typeof(A).GetConstructors().Single(), true, ".ctor()" },
+                {
+                    type.GetConstructors().Single(),
+                    true,
+                    ".ctor(ref double val)"
+                },
+                {
+                    type.GetMethod(nameof(TypeWithMethodsForTest.Test1)),
+                    true,
+                    "object Test1<T1, T2>(out int a, ref string b, object c)"
+                },
+                {
 
-            yield return new object[] { ".ctor()", typeof(B<>).GetConstructors().Single() };
-            yield return new object[] { ".ctor()", typeof(B<int>).GetConstructors().Single() };
-            yield return new object[] { ".ctor()", typeof(A).GetConstructors().Single() };
+                    type.GetMethod(nameof(TypeWithMethodsForTest.Test2)),
+                    false,
+                    "TName Test2<TName>(TName t, Dictionary<TName, int> l)"
+                },
+                {
+                    type.GetMethod(nameof(TypeWithMethodsForTest.Test2)).MakeGenericMethod(typeof(string)),
+                    true,
+                    "string Test2<string>(string t, System.Collections.Generic.Dictionary<string, int> l)"
+                },
+                {
+                    type.GetMethod(nameof(TypeWithMethodsForTest.Test3)),
+                    true,
+                    "bool Test3(bool f, float z, Microsoft.Extensions.Internal.TypeNameHelperTest+A[] p)"
+                }
+            };
         }
 
         [Theory]
-        [MemberData(nameof(GetMethodInfos))]
-        public void Can_pretty_print_method_name(string name, MethodBase methodInfo, bool fullTypeName = true)
+        [MemberData(nameof(GetMethodInfo))]
+        public void Can_pretty_print_method_name(MethodBase methodInfo, bool fullTypeName, string name)
         {
             Assert.Equal(name, TypeNameHelper.GetMethodDisplayName(methodInfo, fullTypeName));
         }

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -3,129 +3,221 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Internal
 {
     public class TypeNameHelperTest
     {
-        [Fact]
-        public void Can_pretty_print_CLR_full_name()
+        [Theory]
+        // Predefined Types
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(List<int>), "System.Collections.Generic.List<int>")]
+        [InlineData(typeof(Dictionary<int, string>), "System.Collections.Generic.Dictionary<int, string>")]
+        [InlineData(typeof(Dictionary<int, List<string>>), "System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>")]
+        [InlineData(typeof(List<List<string>>), "System.Collections.Generic.List<System.Collections.Generic.List<string>>")]
+        // Classes inside NonGeneric class
+        [InlineData(typeof(A),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+A")]
+        [InlineData(typeof(B<int>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+B<int>")]
+        [InlineData(typeof(C<int, string>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, string>")]
+        [InlineData(typeof(B<B<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+B<Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>")]
+        [InlineData(typeof(C<int, B<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>")]
+        // Classes inside Generic class
+        [InlineData(typeof(Outer<int>.D),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+D")]
+        [InlineData(typeof(Outer<int>.E<int>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<int>")]
+        [InlineData(typeof(Outer<int>.F<int, string>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, string>")]
+        [InlineData(typeof(Level1<int>.Level2<bool>.Level3<int>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>")]
+        [InlineData(typeof(Outer<int>.E<Outer<int>.E<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>")]
+        [InlineData(typeof(Outer<int>.F<int, Outer<int>.E<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>")]
+        [InlineData(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>")]
+        public void Can_pretty_print_CLR_full_name(Type type, string expected)
         {
-            // Predefined Types
-            Assert.Equal("int",
-                TypeNameHelper.GetTypeDisplayName(typeof(int)));
-            Assert.Equal("System.Collections.Generic.List<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<int>)));
-            Assert.Equal("System.Collections.Generic.Dictionary<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, string>)));
-            Assert.Equal("System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, List<string>>)));
-            Assert.Equal("System.Collections.Generic.List<System.Collections.Generic.List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<List<string>>)));
-
-            // Classes inside NonGeneric class
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+A",
-                TypeNameHelper.GetTypeDisplayName(typeof(A)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+B<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<int>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, string>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, B<string>>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+B<Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<B<string>>)));
-
-            // Classes inside Generic class
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+D",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.D)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<int>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, string>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, Outer<int>.E<string>>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<Outer<int>.E<string>>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>",
-                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Level1<int>.Level2<bool>.Level3<int>)));
-        }
-
-        [Fact]
-        public void Can_pretty_print_CLR_name()
-        {
-            // Predefined Types
-            Assert.Equal("int",
-                TypeNameHelper.GetTypeDisplayName(typeof(int), false));
-            Assert.Equal("List<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<int>), false));
-            Assert.Equal("Dictionary<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, string>), false));
-            Assert.Equal("Dictionary<int, List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, List<string>>), false));
-            Assert.Equal("List<List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<List<string>>), false));
-
-            // Classes inside NonGeneric class
-            Assert.Equal("A",
-                TypeNameHelper.GetTypeDisplayName(typeof(A), false));
-            Assert.Equal("B<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<int>), false));
-            Assert.Equal("C<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, string>), false));
-            Assert.Equal("C<int, B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, B<string>>), false));
-            Assert.Equal("B<B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<B<string>>), false));
-
-            // Classes inside Generic class
-            Assert.Equal("D",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.D), false));
-            Assert.Equal("E<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<int>), false));
-            Assert.Equal("F<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, string>), false));
-            Assert.Equal("F<int, E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, Outer<int>.E<string>>), false));
-            Assert.Equal("E<E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<Outer<int>.E<string>>), false));
-            Assert.Equal("InnerGenericLeafNode<bool>",
-                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>), false));
-        }
-
-        [Fact]
-        public void Returns_common_name_for_built_in_types()
-        {
-            Assert.Equal("bool", TypeNameHelper.GetTypeDisplayName(typeof(bool)));
-            Assert.Equal("byte", TypeNameHelper.GetTypeDisplayName(typeof(byte)));
-            Assert.Equal("char", TypeNameHelper.GetTypeDisplayName(typeof(char)));
-            Assert.Equal("decimal", TypeNameHelper.GetTypeDisplayName(typeof(decimal)));
-            Assert.Equal("double", TypeNameHelper.GetTypeDisplayName(typeof(double)));
-            Assert.Equal("float", TypeNameHelper.GetTypeDisplayName(typeof(float)));
-            Assert.Equal("int", TypeNameHelper.GetTypeDisplayName(typeof(int)));
-            Assert.Equal("long", TypeNameHelper.GetTypeDisplayName(typeof(long)));
-            Assert.Equal("object", TypeNameHelper.GetTypeDisplayName(typeof(object)));
-            Assert.Equal("sbyte", TypeNameHelper.GetTypeDisplayName(typeof(sbyte)));
-            Assert.Equal("short", TypeNameHelper.GetTypeDisplayName(typeof(short)));
-            Assert.Equal("string", TypeNameHelper.GetTypeDisplayName(typeof(string)));
-            Assert.Equal("uint", TypeNameHelper.GetTypeDisplayName(typeof(uint)));
-            Assert.Equal("ulong", TypeNameHelper.GetTypeDisplayName(typeof(ulong)));
-            Assert.Equal("ushort", TypeNameHelper.GetTypeDisplayName(typeof(ushort)));
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
         }
 
         [Theory]
-        [InlineData("int[]", typeof(int[]))]
-        [InlineData("string[][]", typeof(string[][]))]
-        [InlineData("int[,]", typeof(int[,]))]
-        [InlineData("bool[,,,]", typeof(bool[,,,]))]
-        [InlineData("Microsoft.Extensions.Internal.TypeNameHelperTest+A[,][,,]", typeof(A[,][,,]))]
-        [InlineData("System.Collections.Generic.List<int[,][,,]>", typeof(List<int[,][,,]>))]
-        [InlineData("List<int[,,][,]>[,][,,]", typeof(List<int[,,][,]>[,][,,]), false)]
-        public void Can_pretty_print_array_name(string expected, Type type, bool fullName = true)
+        // Predefined Types
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(List<int>), "List<int>")]
+        [InlineData(typeof(Dictionary<int, string>), "Dictionary<int, string>")]
+        [InlineData(typeof(Dictionary<int, List<string>>), "Dictionary<int, List<string>>")]
+        [InlineData(typeof(List<List<string>>), "List<List<string>>")]
+        // Classes inside NonGeneric class
+        [InlineData(typeof(A), "A")]
+        [InlineData(typeof(B<int>), "B<int>")]
+        [InlineData(typeof(C<int, string>), "C<int, string>")]
+        [InlineData(typeof(C<int, B<string>>), "C<int, B<string>>")]
+        [InlineData(typeof(B<B<string>>), "B<B<string>>")]
+        // Classes inside Generic class
+        [InlineData(typeof(Outer<int>.D), "D")]
+        [InlineData(typeof(Outer<int>.E<int>), "E<int>")]
+        [InlineData(typeof(Outer<int>.F<int, string>), "F<int, string>")]
+        [InlineData(typeof(Outer<int>.F<int, Outer<int>.E<string>>), "F<int, E<string>>")]
+        [InlineData(typeof(Outer<int>.E<Outer<int>.E<string>>), "E<E<string>>")]
+        [InlineData(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>), "InnerGenericLeafNode<bool>")]
+        public void Can_pretty_print_CLR_name(Type type, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, false));
+        }
+
+        [Theory]
+        [InlineData(typeof(void), "void")]
+        [InlineData(typeof(bool), "bool")]
+        [InlineData(typeof(byte), "byte")]
+        [InlineData(typeof(char), "char")]
+        [InlineData(typeof(decimal), "decimal")]
+        [InlineData(typeof(double), "double")]
+        [InlineData(typeof(float), "float")]
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(long), "long")]
+        [InlineData(typeof(object), "object")]
+        [InlineData(typeof(sbyte), "sbyte")]
+        [InlineData(typeof(short), "short")]
+        [InlineData(typeof(string), "string")]
+        [InlineData(typeof(uint), "uint")]
+        [InlineData(typeof(ulong), "ulong")]
+        [InlineData(typeof(ushort), "ushort")]
+        public void Returns_common_name_for_built_in_types(Type type, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
+        }
+
+        [Theory]
+        [InlineData(typeof(int[]), true, "int[]")]
+        [InlineData(typeof(string[][]), true, "string[][]")]
+        [InlineData(typeof(int[,]), true, "int[,]")]
+        [InlineData(typeof(bool[,,,]), true, "bool[,,,]")]
+        [InlineData(typeof(A[,][,,]), true, "Microsoft.Extensions.Internal.TypeNameHelperTest+A[,][,,]")]
+        [InlineData(typeof(List<int[,][,,]>), true, "System.Collections.Generic.List<int[,][,,]>")]
+        [InlineData(typeof(List<int[,,][,]>[,][,,]), false, "List<int[,,][,]>[,][,,]")]
+        public void Can_pretty_print_array_name(Type type, bool fullName, string expected)
         {
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
+        }
+
+        public static TheoryData GetOpenGenericsTestData()
+        {
+            var openDictionaryType = typeof(Dictionary<,>);
+            var genArgsDictionary = openDictionaryType.GetGenericArguments();
+            genArgsDictionary[0] = typeof(B<>);
+            var closedDictionaryType = openDictionaryType.MakeGenericType(genArgsDictionary);
+
+            var openLevelType = typeof(Level1<>.Level2<>.Level3<>);
+            var genArgsLevel = openLevelType.GetGenericArguments();
+            genArgsLevel[1] = typeof(string);
+            var closedLevelType = openLevelType.MakeGenericType(genArgsLevel);
+
+            var openInnerType = typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>);
+            var genArgsInnerType = openInnerType.GetGenericArguments();
+            genArgsInnerType[3] = typeof(bool);
+            var closedInnerType = openInnerType.MakeGenericType(genArgsInnerType);
+
+            return new TheoryData<Type, bool, string>
+            {
+                { typeof(List<>), false, "List<>" },
+                { typeof(Dictionary<,>), false , "Dictionary<,>" },
+                { typeof(List<>), true , "System.Collections.Generic.List<>" },
+                { typeof(Dictionary<,>), true , "System.Collections.Generic.Dictionary<,>" },
+                { typeof(Level1<>.Level2<>.Level3<>), true, "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<>+Level3<>" },
+                {
+                    typeof(PartiallyClosedGeneric<>).BaseType,
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+C<, int>"
+                },
+                {
+                    typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>),
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<>"
+                },
+                {
+                    closedDictionaryType,
+                    true,
+                    "System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<>,>"
+                },
+                {
+                    closedLevelType,
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<string>+Level3<>"
+                },
+                {
+                    closedInnerType,
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<bool>"
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetOpenGenericsTestData))]
+        public void Can_pretty_print_open_generics(Type type, bool fullName, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
+        }
+
+        public static IEnumerable<object[]> GetMethodInfos()
+        {
+            var type = typeof(TypeWithMethodsForTest);
+            yield return new object[]
+            {
+                ".ctor(ref double val)",
+                type.GetConstructors().Single()
+            };
+            yield return new object[]
+            {
+                "object Test1<T1, T2>(out int a, ref string b, object c)",
+                type.GetMethod(nameof(TypeWithMethodsForTest.Test1))
+            };
+            yield return new object[]
+            {
+                "TName Test2<TName>(TName t, Dictionary<TName, int> l)",
+                type.GetMethod(nameof(TypeWithMethodsForTest.Test2)),
+                false
+            };
+            yield return new object[]
+            {
+                "string Test2<string>(string t, System.Collections.Generic.Dictionary<string, int> l)",
+                type.GetMethod(nameof(TypeWithMethodsForTest.Test2)).MakeGenericMethod(typeof(string))
+            };
+            yield return new object[]
+            {
+                "bool Test3(bool f, float z, Microsoft.Extensions.Internal.TypeNameHelperTest+A[] p)",
+                type.GetMethod(nameof(TypeWithMethodsForTest.Test3))
+            };
+
+            yield return new object[] { ".ctor()", typeof(B<>).GetConstructors().Single() };
+            yield return new object[] { ".ctor()", typeof(B<int>).GetConstructors().Single() };
+            yield return new object[] { ".ctor()", typeof(A).GetConstructors().Single() };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMethodInfos))]
+        public void Can_pretty_print_method_name(string name, MethodBase methodInfo, bool fullTypeName = true)
+        {
+            Assert.Equal(name, TypeNameHelper.GetMethodDisplayName(methodInfo, fullTypeName));
+        }
+
+        private class TypeWithMethodsForTest
+        {
+            public TypeWithMethodsForTest(ref double val) { }
+            public object Test1<T1, T2>(out int a, ref string b, object c = null) => a = 0;
+            public TName Test2<TName>(TName t, Dictionary<TName, int> l) => default;
+            public bool Test3(bool f, float z = 1, params A[] p) => false;
         }
 
         private class A { }
@@ -133,6 +225,8 @@ namespace Microsoft.Extensions.Internal
         private class B<T> { }
 
         private class C<T1, T2> { }
+
+        private class PartiallyClosedGeneric<T> : C<T, int> { }
 
         private class Outer<T>
         {


### PR DESCRIPTION
Add method `string GetMethodDisplayName(MethodInfo method, bool fullTypeName = true)` to `TypeNameHelper`.

This method could be useful in [aspnet/DependencyInjection](https://github.com/aspnet/DependencyInjection/blob/958e821ba0dff1ca0c885bd8d158c7e936105a4f/src/DI/ServiceLookup/CallSiteFactory.cs#L302) to display a list of constructors and other places.

Output examples:
- simple method:
`bool MethodName(int param1, ref float param2, out bool param3)`,
- open generic method:
`object MethodName<T1, T2>(int param1, T param2)`,
- generic method:
`string Test2<string>(string param1, List<string> param2)`,
- constructor:
` .ctor(ref double val)`.
