### PR TITLE
Add void to predefined names in TypeNameHelper

### DIFF
--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Internal
     {
         private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string>
             {
+            { typeof(void), "void" },
             { typeof(bool), "bool" },
             { typeof(byte), "byte" },
             { typeof(char), "char" },

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Extensions.Internal
         [Fact]
         public void Returns_common_name_for_built_in_types()
         {
+            Assert.Equal("void", TypeNameHelper.GetTypeDisplayName(typeof(void)));
             Assert.Equal("bool", TypeNameHelper.GetTypeDisplayName(typeof(bool)));
             Assert.Equal("byte", TypeNameHelper.GetTypeDisplayName(typeof(byte)));
             Assert.Equal("char", TypeNameHelper.GetTypeDisplayName(typeof(char)));


### PR DESCRIPTION
I think `void` should also have a short name like `int`, `string` etc.
Before: `System.Void`
After: `void`