### PR TITLE
Pin tool and package versions to reduce build non-determinism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ node_modules/
 **/[Cc]ompiler/[Rr]esources/**/*.js
 .vscode/
 global.json
-korebuild-lock.txt

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
-  <Import Project="version.xml" />
+  <Import Project="version.props" />
+  <Import Project="build\dependencies.props" />
 
   <PropertyGroup>
     <Product>Microsoft .NET Extensions</Product>
@@ -9,7 +10,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)build\Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-    <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,14 +1,5 @@
-<Project InitialTargets="EnsureKoreBuildRestored">
-  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true' ">
-    <PropertyGroup>
-      <_BootstrapperFile Condition=" $([MSBuild]::IsOSUnixLike()) ">build.sh</_BootstrapperFile>
-      <_BootstrapperFile Condition="! $([MSBuild]::IsOSUnixLike()) ">build.cmd</_BootstrapperFile>
-      <_BootstrapperError>
-        Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'.
-        Also, you can run './$(_BootstrapperFile) /t:Restore' which will pin *and* restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'.
-      </_BootstrapperError>
-    </PropertyGroup>
-
-    <Error Code="KRB1001" Text="$(_BootstrapperError.Trim())" />
-  </Target>
+<Project>
+  <PropertyGroup>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
+    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,0 +1,21 @@
+﻿<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <PropertyGroup Label="Package Versions">
+    <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.1-preview1-15540</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
+    <MoqPackageVersion>4.7.49</MoqPackageVersion>
+    <NETStandardLibraryPackageVersion>2.0.0</NETStandardLibraryPackageVersion>
+    <SystemReflectionMetadataPackageVersion>1.5.0</SystemReflectionMetadataPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.4.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>4.4.0</SystemSecurityCryptographyCngPackageVersion>
+    <SystemThreadingTasksExtensionsPackageVersion>4.4.0</SystemThreadingTasksExtensionsPackageVersion>
+    <XunitAnalyzersPackageVersion>0.7.0</XunitAnalyzersPackageVersion>
+    <XunitPackageVersion>2.3.0</XunitPackageVersion>
+    <XunitRunnerVisualstudioPackageVersion>2.3.0</XunitRunnerVisualstudioPackageVersion>
+  </PropertyGroup>
+  <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
+</Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,6 +1,6 @@
 <Project>
-  <ItemGroup>
-    <PackageLineup Include="Internal.AspNetCore.Universe.Lineup" Version="2.1.0-*" />
-    <PackageLineup Include="Internal.AspNetCore.Partners.Lineup" Version="2.1.0-*" />
-  </ItemGroup>
+  <PropertyGroup>
+    <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
+    <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json</LineupPackageRestoreSource>
+  </PropertyGroup>
 </Project>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,0 +1,2 @@
+version:2.1.0-preview1-15540
+commithash:f9a4508dd777e091f39ec57a53c4f514eaca8c39

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
+  "channel": "dev"
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" />
+    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.csproj
+++ b/src/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.csproj
@@ -17,7 +17,7 @@ Microsoft.Extensions.Primitives.StringSegment</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,11 +2,11 @@
   <Import Project="..\Directory.Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.analyzers" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
+++ b/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
@@ -29,10 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" />
-    <PackageReference Include="System.Reflection.Metadata" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="System.Security.Cryptography.Cng" />
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCorePackageVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataPackageVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionSuffix>preview1</VersionSuffix>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
+    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/version.xml
+++ b/version.xml
@@ -1,8 +1,0 @@
-<!-- This file may be overwritten by automation. -->
-<Project>
-    <PropertyGroup>
-        <KoreBuildChannel>dev</KoreBuildChannel>
-        <VersionPrefix>2.1.0</VersionPrefix>
-        <VersionSuffix>preview1</VersionSuffix>
-    </PropertyGroup>
-</Project>


### PR DESCRIPTION
Part of https://github.com/aspnet/KoreBuild/issues/239 and https://github.com/aspnet/Universe/issues/575

This change removes some sources of non-determinism in our build. Package versions are hard-coded and do not float, and the build tools version is committed to source.

In addition, it removes the need for devs to run `build.cmd /t:Pin` before opening VS. 