### PR TITLE
Make stack traces readable

### DIFF
--- a/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/MethodDisplayInfo.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/MethodDisplayInfo.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Extensions.StackTrace.Sources
 
         public string GenericArguments { get; set; }
 
+        public string SubMethod { get; set; }
+
         public IEnumerable<ParameterDisplayInfo> Parameters { get; set; }
 
         public override string ToString()
@@ -33,6 +35,13 @@ namespace Microsoft.Extensions.StackTrace.Sources
             builder.Append("(");
             builder.Append(string.Join(", ", Parameters.Select(p => p.ToString())));
             builder.Append(")");
+
+            if (!string.IsNullOrEmpty(SubMethod))
+            {
+                builder.Append("+");
+                builder.Append(SubMethod);
+                builder.Append("()");
+            }
 
             return builder.ToString();
         }

--- a/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.StackTrace.Sources
@@ -31,9 +34,16 @@ namespace Microsoft.Extensions.StackTrace.Sources
                     return frames;
                 }
 
-                foreach (var frame in stackFrames)
+                for(var i = 0; i < stackFrames.Length; i++)
                 {
+                    var frame = stackFrames[i];
                     var method = frame.GetMethod();
+
+                    // Always show last stackFrame
+                    if (!ShowInStackTrace(method) && i < stackFrames.Length - 1)
+                    {
+                        continue;
+                    }
 
                     var stackFrame = new StackFrameInfo
                     {
@@ -67,8 +77,22 @@ namespace Microsoft.Extensions.StackTrace.Sources
 
             var methodDisplayInfo = new MethodDisplayInfo();
 
+
             // Type name
             var type = method.DeclaringType;
+
+            var methodName = method.Name;
+
+            if (type != null && type.IsDefined(typeof(CompilerGeneratedAttribute)) &&
+                (typeof(IAsyncStateMachine).IsAssignableFrom(type) || typeof(IEnumerator).IsAssignableFrom(type)))
+            {
+                // Convert StateMachine methods to correct overload +MoveNext()
+                if (TryResolveStateMachineMethod(ref method, out type))
+                {
+                    methodDisplayInfo.SubMethod = methodName;
+                }
+            }
+            // ResolveStateMachineMethod may have set declaringType to null
             if (type != null)
             {
                 methodDisplayInfo.DeclaringTypeName = TypeNameHelper.GetTypeDisplayName(type);
@@ -118,6 +142,82 @@ namespace Microsoft.Extensions.StackTrace.Sources
             });
 
             return methodDisplayInfo;
+        }
+
+        private static bool ShowInStackTrace(MethodBase method)
+        {
+            Debug.Assert(method != null);
+
+            // Don't show any methods marked with the StackTraceHiddenAttribute
+            // https://github.com/dotnet/coreclr/pull/14652
+            foreach (var attibute in method.CustomAttributes)
+            {
+                // internal Attribute, match on name
+                if (attibute.AttributeType.Name == "StackTraceHiddenAttribute")
+                {
+                    return false;
+                }
+            }
+
+            var type = method.DeclaringType;
+            if (type == null)
+            {
+                return true;
+            }
+
+            foreach (var attibute in type.CustomAttributes)
+            {
+                // internal Attribute, match on name
+                if (attibute.AttributeType.Name == "StackTraceHiddenAttribute")
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
+        {
+            Debug.Assert(method != null);
+            Debug.Assert(method.DeclaringType != null);
+
+            declaringType = method.DeclaringType;
+
+            var parentType = declaringType.DeclaringType;
+            if (parentType == null)
+            {
+                return false;
+            }
+
+            var methods = parentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            if (methods == null)
+            {
+                return false;
+            }
+
+            foreach (var candidateMethod in methods)
+            {
+                var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>();
+                if (attributes == null)
+                {
+                    continue;
+                }
+
+                foreach (var asma in attributes)
+                {
+                    if (asma.StateMachineType == declaringType)
+                    {
+                        method = candidateMethod;
+                        declaringType = candidateMethod.DeclaringType;
+                        // Mark the iterator as changed; so it gets the + annotation of the original method
+                        // async statemachines resolve directly to their builder methods so aren't marked as changed
+                        return asma is IteratorStateMachineAttribute;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.StackTrace.Sources
@@ -171,6 +172,26 @@ namespace Microsoft.Extensions.StackTrace.Sources
                 if (attibute.AttributeType.Name == "StackTraceHiddenAttribute")
                 {
                     return false;
+                }
+            }
+
+            // Fallbacks for runtime pre-StackTraceHiddenAttribute
+            if (type == typeof(ExceptionDispatchInfo) && method.Name == "Throw")
+            {
+                return false;
+            }
+            else if (type == typeof(TaskAwaiter) ||
+                     type == typeof(TaskAwaiter<>) ||
+                     type == typeof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter) ||
+                     type == typeof(ConfiguredTaskAwaitable<>.ConfiguredTaskAwaiter))
+            {
+                switch (method.Name)
+                {
+                    case "HandleNonSuccessAndDebuggerNotification":
+                    case "ThrowForNonSuccess":
+                    case "ValidateEnd":
+                    case "GetResult":
+                        return false;
                 }
             }
 

--- a/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.StackTrace.Sources
                     return frames;
                 }
 
-                for(var i = 0; i < stackFrames.Length; i++)
+                for (var i = 0; i < stackFrames.Length; i++)
                 {
                     var frame = stackFrames[i];
                     var method = frame.GetMethod();
@@ -180,10 +180,10 @@ namespace Microsoft.Extensions.StackTrace.Sources
             {
                 return false;
             }
-            else if (type == typeof(TaskAwaiter) ||
-                     type == typeof(TaskAwaiter<>) ||
-                     type == typeof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter) ||
-                     type == typeof(ConfiguredTaskAwaitable<>.ConfiguredTaskAwaiter))
+            else if (type == typeof(TaskAwaiter) || 
+                type == typeof(TaskAwaiter<>) ||
+                type == typeof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter) ||
+                type == typeof(ConfiguredTaskAwaitable<>.ConfiguredTaskAwaiter))
             {
                 switch (method.Name)
                 {
@@ -193,6 +193,10 @@ namespace Microsoft.Extensions.StackTrace.Sources
                     case "GetResult":
                         return false;
                 }
+            }
+            else if (type.FullName == "System.ThrowHelper")
+            {
+                return false;
             }
 
             return true;

--- a/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
+++ b/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/StackTraceHelper.cs
@@ -194,10 +194,6 @@ namespace Microsoft.Extensions.StackTrace.Sources
                         return false;
                 }
             }
-            else if (type.FullName == "System.ThrowHelper")
-            {
-                return false;
-            }
 
             return true;
         }

--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Internal
 
         private static void ProcessTypeName(Type t, StringBuilder sb, bool fullName)
         {
-            if (t.GetTypeInfo().IsGenericType)
+            if (t.IsGenericType)
             {
                 ProcessNestedGenericTypes(t, sb, fullName);
                 return;
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.Internal
             }
             else
             {
-                sb.Append(fullName ? t.FullName : t.Name);
+                sb.Append(fullName ? t.FullName ?? t.Name : t.Name);
             }
         }
 
@@ -81,7 +81,8 @@ namespace Microsoft.Extensions.Internal
             var genericFullName = t.GetGenericTypeDefinition().FullName;
             var genericSimpleName = t.GetGenericTypeDefinition().Name;
             var parts = genericFullName.Split('+');
-            var genericArguments = t.GetTypeInfo().GenericTypeArguments;
+            var genericArguments = t.GetGenericArguments();
+
             var index = 0;
             var totalParts = parts.Length;
             if (totalParts == 1)

--- a/test/Microsoft.Extensions.Internal.Test/StackTraceHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/StackTraceHelperTest.cs
@@ -78,7 +78,9 @@ namespace Microsoft.Extensions.Internal
 
             var methodNames = stackFrames.Select(stackFrame => stackFrame.MethodDisplayInfo.ToString())
                 // Remove Framework method that can be optimized out (inlined)
-                .Where(methodName => methodName != "System.Collections.Generic.List<T>+Enumerator.MoveNext()");
+                .Where(methodName => methodName != "System.Collections.Generic.List<T>+Enumerator.MoveNext()")
+                // Remove stack frame that may be excluded by the runtime
+                .Where(methodName => methodName != "System.ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion()");
 
             // Assert
             Assert.Equal(expectedCallStack, methodNames);

--- a/test/Microsoft.Extensions.Internal.Test/StackTraceHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/StackTraceHelperTest.cs
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.StackTrace.Sources;
 using ThrowingLibrary;
 using Xunit;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Internal
 {
@@ -41,6 +45,88 @@ namespace Microsoft.Extensions.Internal
                 {
                     Assert.Contains("StackTraceHelperTest.cs", frame.FilePath);
                 });
+        }
+
+        [Fact]
+        public void StackTraceHelper_ProducesReadableOutput()
+        {
+            // Arrange
+            var expectedCallStack = new List<string>()
+            {
+                "System.Collections.Generic.List<T>+Enumerator.MoveNextRare()",
+                "Microsoft.Extensions.Internal.StackTraceHelperTest.Iterator()+MoveNext()",
+                "string.Join(string separator, IEnumerable<string> values)",
+                "Microsoft.Extensions.Internal.StackTraceHelperTest+GenericClass<T>.GenericMethod<V>(ref V value)",
+                "Microsoft.Extensions.Internal.StackTraceHelperTest.MethodAsync(int value)",
+                "Microsoft.Extensions.Internal.StackTraceHelperTest.MethodAsync<TValue>(TValue value)",
+                "Microsoft.Extensions.Internal.StackTraceHelperTest.Method(string value)",
+                "Microsoft.Extensions.Internal.StackTraceHelperTest.StackTraceHelper_ProducesReadableOutput()"
+            };
+
+            Exception exception = null;
+            try
+            {
+                Method("test");
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // Act
+            var stackFrames = StackTraceHelper.GetFrames(exception);
+
+            var methodNames = stackFrames.Select(stackFrame => stackFrame.MethodDisplayInfo.ToString())
+                // Remove Framework method that can be optimized out (inlined)
+                .Where(methodName => methodName != "System.Collections.Generic.List<T>+Enumerator.MoveNext()");
+
+            // Assert
+            Assert.Equal(expectedCallStack, methodNames);
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        async Task<string> MethodAsync(int value)
+        {
+            await Task.Delay(0);
+            return GenericClass<byte>.GenericMethod(ref value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        async Task<string> MethodAsync<TValue>(TValue value)
+        {
+            return await MethodAsync(1);
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        string Method(string value)
+        {
+            return MethodAsync(value).GetAwaiter().GetResult();
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        static IEnumerable<string> Iterator()
+        {
+            var list = new List<int>() {1, 2, 3, 4};
+            foreach (var item in list)
+            {
+                list.Add(item);
+
+                yield return item.ToString();
+            }
+        }
+
+        class GenericClass<T>
+        {
+            [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+            public static string GenericMethod<V>(ref V value)
+            {
+                var returnVal = "";
+                for (var i = 0; i < 10; i++)
+                {
+                    returnVal += string.Join(", ", Iterator());
+                }
+                return returnVal;
+            }
         }
     }
 }


### PR DESCRIPTION
Brings upstream the coreclr PRs which work on `Exception.ToString` to work on the `StackFrames` for a far more productive trouble-shooting experience.

"Hide post exception stack frames" https://github.com/dotnet/coreclr/pull/14652
"Resolve iterators and async methods"  stacktrace https://github.com/dotnet/coreclr/pull/14655

`Microsoft.AspNetCore.Diagnostics` works on `StackFrames` rather than the `.ToString()` so it won't automatically fix with those PRs (except the "Show raw exception details" bit)


**"Hide post exception stack frames"** drops
```
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() 
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) 
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task) 
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult() 
```

**"Resolve iterators and async methods"** converts
```
Program.<Iterator>d__4.MoveNext()
```
to the correct method signature
```
Program.Iterator(Int64 count, Int32 value)+MoveNext()
```

However it will need a recent build of coreclr to drop the Task/ExceptionDispatchInfo stuff as that's a new Attribute on the methods/Types.

/cc @DamianEdwards @davidfowl 