### PR TITLE
Refactor nested generic display in TypeNameHelper

### DIFF
--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -36,11 +36,11 @@ namespace Microsoft.Extensions.Internal
         public static string GetTypeDisplayName(Type type, bool fullName = true)
         {
             var builder = new StringBuilder();
-            ProcessTypeName(builder, type, fullName);
+            ProcessType(builder, type, fullName);
             return builder.ToString();
         }
 
-        private static void ProcessTypeName(StringBuilder builder, Type type, bool fullName)
+        private static void ProcessType(StringBuilder builder, Type type, bool fullName)
         {
             if (type.IsGenericType)
             {
@@ -55,6 +55,10 @@ namespace Microsoft.Extensions.Internal
             {
                 builder.Append(buildInName);
             }
+            else
+            {
+                builder.Append(fullName ? type.FullName : type.Name);
+            }
         }
 
         private static void ProcessArrayType(StringBuilder builder, Type type, bool fullName)
@@ -65,13 +69,13 @@ namespace Microsoft.Extensions.Internal
                 innerType = innerType.GetElementType();
             }
 
-            ProcessTypeName(builder, innerType, fullName);
+            ProcessType(builder, innerType, fullName);
 
             while (type.IsArray)
             {
-                builder.Append("[");
+                builder.Append('[');
                 builder.Append(',', type.GetArrayRank() - 1);
-                builder.Append("]");
+                builder.Append(']');
                 type = type.GetElementType();
             }
         }
@@ -110,7 +114,7 @@ namespace Microsoft.Extensions.Internal
             builder.Append('<');
             for (var i = offset; i < length; i++)
             {
-                ProcessTypeName(builder, genericArguments[i], fullName);
+                ProcessType(builder, genericArguments[i], fullName);
                 if (i + 1 != length)
                 {
                     builder.Append(", ");

--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 
 namespace Microsoft.Extensions.Internal
@@ -36,97 +35,69 @@ namespace Microsoft.Extensions.Internal
 
         public static string GetTypeDisplayName(Type type, bool fullName = true)
         {
-            var sb = new StringBuilder();
-            ProcessTypeName(type, sb, fullName);
-            return sb.ToString();
+            var builder = new StringBuilder();
+            ProcessTypeName(builder, type, fullName);
+            return builder.ToString();
         }
 
-        private static void AppendGenericArguments(Type[] args, int startIndex, int numberOfArgsToAppend, StringBuilder sb, bool fullName)
+        private static void ProcessTypeName(StringBuilder builder, Type type, bool fullName)
         {
-            var totalArgs = args.Length;
-            if (totalArgs >= startIndex + numberOfArgsToAppend)
+            if (type.IsGenericType)
             {
-                sb.Append("<");
-                for (int i = startIndex; i < startIndex + numberOfArgsToAppend; i++)
-                {
-                    ProcessTypeName(args[i], sb, fullName);
-                    if (i + 1 < startIndex + numberOfArgsToAppend)
-                    {
-                        sb.Append(", ");
-                    }
-                }
-                sb.Append(">");
+                var genericArguments = type.GetGenericArguments();
+                ProcessGenericType(builder, type, genericArguments, genericArguments.Length, fullName);
             }
-        }
-
-        private static void ProcessTypeName(Type t, StringBuilder sb, bool fullName)
-        {
-            if (t.GetTypeInfo().IsGenericType)
+            else if (_builtInTypeNames.TryGetValue(type, out var buildInName))
             {
-                ProcessNestedGenericTypes(t, sb, fullName);
-                return;
-            }
-            if (_builtInTypeNames.ContainsKey(t))
-            {
-                sb.Append(_builtInTypeNames[t]);
+                builder.Append(buildInName);
             }
             else
             {
-                sb.Append(fullName ? t.FullName : t.Name);
+                builder.Append(fullName ? type.FullName : type.Name);
             }
         }
 
-        private static void ProcessNestedGenericTypes(Type t, StringBuilder sb, bool fullName)
+        private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, bool fullName)
         {
-            var genericFullName = t.GetGenericTypeDefinition().FullName;
-            var genericSimpleName = t.GetGenericTypeDefinition().Name;
-            var parts = genericFullName.Split('+');
-            var genericArguments = t.GetTypeInfo().GenericTypeArguments;
-            var index = 0;
-            var totalParts = parts.Length;
-            if (totalParts == 1)
+            var offset = 0;
+            if (type.IsNested)
             {
-                var part = parts[0];
-                var num = part.IndexOf('`');
-                if (num == -1) return;
-
-                var name = part.Substring(0, num);
-                var numberOfGenericTypeArgs = int.Parse(part.Substring(num + 1));
-                sb.Append(fullName ? name : genericSimpleName.Substring(0, genericSimpleName.IndexOf('`')));
-                AppendGenericArguments(genericArguments, index, numberOfGenericTypeArgs, sb, fullName);
-                return;
+                offset = type.DeclaringType.GetGenericArguments().Length;
             }
-            for (var i = 0; i < totalParts; i++)
+
+            if (fullName)
             {
-                var part = parts[i];
-                var num = part.IndexOf('`');
-                if (num != -1)
+                if (type.IsNested)
                 {
-                    var name = part.Substring(0, num);
-                    var numberOfGenericTypeArgs = int.Parse(part.Substring(num + 1));
-                    if (fullName || i == totalParts - 1)
-                    {
-                        sb.Append(name);
-                        AppendGenericArguments(genericArguments, index, numberOfGenericTypeArgs, sb, fullName);
-                    }
-                    if (fullName && i != totalParts - 1)
-                    {
-                        sb.Append("+");
-                    }
-                    index += numberOfGenericTypeArgs;
+                    ProcessGenericType(builder, type.DeclaringType, genericArguments, offset, fullName);
+                    builder.Append('+');
                 }
                 else
                 {
-                    if (fullName || i == totalParts - 1)
-                    {
-                        sb.Append(part);
-                    }
-                    if (fullName && i != totalParts - 1)
-                    {
-                        sb.Append("+");
-                    }
+                    builder.Append(type.Namespace);
+                    builder.Append('.');
                 }
             }
+
+            var genericPartIndex = type.Name.IndexOf('`');
+            if (genericPartIndex <= 0)
+            {
+                builder.Append(type.Name);
+                return;
+            }
+
+            builder.Append(type.Name, 0, genericPartIndex);
+
+            builder.Append('<');
+            for (var i = offset; i < length; i++)
+            {
+                ProcessTypeName(builder, genericArguments[i], fullName);
+                if (i + 1 != length)
+                {
+                    builder.Append(", ");
+                }
+            }
+            builder.Append('>');
         }
     }
 }

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Extensions.Internal
                 TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, Outer<int>.E<string>>)));
             Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
                 TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<Outer<int>.E<string>>)));
+            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>",
+                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>)));
+            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>",
+                TypeNameHelper.GetTypeDisplayName(typeof(Level1<int>.Level2<bool>.Level3<int>)));
         }
 
         [Fact]
@@ -86,6 +90,8 @@ namespace Microsoft.Extensions.Internal
                 TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, Outer<int>.E<string>>), false));
             Assert.Equal("E<E<string>>",
                 TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<Outer<int>.E<string>>), false));
+            Assert.Equal("InnerGenericLeafNode<bool>",
+                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>), false));
         }
 
         [Fact]
@@ -120,6 +126,29 @@ namespace Microsoft.Extensions.Internal
             public class E<T1> { }
 
             public class F<T1, T2> { }
+        }
+
+        private class OuterGeneric<T1>
+        {
+            public class InnerNonGeneric
+            {
+                public class InnerGeneric<T2, T3>
+                {
+                    public class InnerGenericLeafNode<T4> { }
+
+                    public class InnerLeafNode { }
+                }
+            }
+        }
+
+        private class Level1<T1>
+        {
+            public class Level2<T2>
+            {
+                public class Level3<T3>
+                {
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This implementation for getting display name of nested generics types uses `Type.DeclaringType` to display it instead splitting full name string and parsing `int` values in it.