### PR TITLE
add ValueStopwatch for timing without allocations

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -16,7 +16,8 @@
       "Microsoft.Extensions.SecurityHelper.Sources": {},
       "Microsoft.Extensions.StackTrace.Sources": {},
       "Microsoft.Extensions.TypeNameHelper.Sources": {},
-      "Microsoft.Extensions.WebEncoders.Sources": {}
+      "Microsoft.Extensions.WebEncoders.Sources": {},
+      "Microsoft.Extensions.ValueStopwatch.Sources": {}
     }
   },
   "Default": {

--- a/shared/Microsoft.Extensions.ValueStopwatch.Sources/ValueStopwatch.cs
+++ b/shared/Microsoft.Extensions.ValueStopwatch.Sources/ValueStopwatch.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 

--- a/shared/Microsoft.Extensions.ValueStopwatch.Sources/ValueStopwatch.cs
+++ b/shared/Microsoft.Extensions.ValueStopwatch.Sources/ValueStopwatch.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Extensions.Internal 
+{
+    internal struct ValueStopwatch
+    {
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        private long _startTimestamp;
+
+        private ValueStopwatch(long startTimestamp)
+        {
+            _startTimestamp = startTimestamp;
+        }
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+        public TimeSpan GetElapsedTime()
+        {
+            // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+            // So it being 0 is a clear indication of default(ValueStopwatch)
+            if (_startTimestamp == 0)
+            {
+                throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+            }
+
+            var end = Stopwatch.GetTimestamp();
+            var timestampDelta = end - _startTimestamp;
+            var ticks = (long)(TimestampToTicks * timestampDelta);
+            return new TimeSpan(ticks);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
+++ b/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.AspNetCore.Certificates.Generation.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.ActivatorUtilities.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.ClosedGenericMatcher.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.CopyOnWriteDictionary.Sources\**\*.cs" />
@@ -19,8 +20,8 @@
     <Compile Include="..\..\shared\Microsoft.Extensions.SecurityHelper.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.StackTrace.Sources\StackFrame\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.TypeNameHelper.Sources\**\*.cs" />
+    <Compile Include="..\..\shared\Microsoft.Extensions.ValueStopwatch.Sources\**\*.cs" />
     <Compile Include="..\..\shared\Microsoft.Extensions.WebEncoders.Sources\**\*.cs" />
-    <Compile Include="..\..\shared\Microsoft.AspNetCore.Certificates.Generation.Sources\**\*.cs" />
     <EmbeddedResource Include="..\..\shared\*.Sources\**\*.resx" />
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.Internal.Test/ValueStopwatchTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ValueStopwatchTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Xunit;

--- a/test/Microsoft.Extensions.Internal.Test/ValueStopwatchTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ValueStopwatchTest.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.Internal.Test
+{
+    public class ValueStopwatchTest
+    {
+        [Fact]
+        public void GetElapsedTimeThrowsIfValueStopwatchIsDefaultValue()
+        {
+            var stopwatch = default(ValueStopwatch);
+            Assert.Throws<InvalidOperationException>(() => stopwatch.GetElapsedTime());
+        }
+
+        [Fact]
+        public async Task GetElapsedTimeReturnsTimeElapsedSinceStart()
+        {
+            var stopwatch = ValueStopwatch.StartNew();
+            await Task.Delay(200);
+            Assert.True(stopwatch.GetElapsedTime().TotalMilliseconds > 0);
+        }
+    }
+}


### PR DESCRIPTION
Obviously it's still possible for this to allocate if the code being timed goes async or otherwise needs to be captured on the heap, but this allows the timing code to have no impact beyond an additional `long`, rather than a whole heap-allocated class (in the case of `Stopwatch`).