### PR TITLE
add IsActive flag to ValueStopwatch

### DIFF
--- a/shared/Microsoft.Extensions.ValueStopwatch.Sources/ValueStopwatch.cs
+++ b/shared/Microsoft.Extensions.ValueStopwatch.Sources/ValueStopwatch.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Extensions.Internal
 
         private long _startTimestamp;
 
+        public bool IsActive => _startTimestamp != 0;
+
         private ValueStopwatch(long startTimestamp)
         {
             _startTimestamp = startTimestamp;
@@ -23,7 +25,7 @@ namespace Microsoft.Extensions.Internal
         {
             // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
             // So it being 0 is a clear indication of default(ValueStopwatch)
-            if (_startTimestamp == 0)
+            if (!IsActive)
             {
                 throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
             }

--- a/test/Microsoft.Extensions.Internal.Test/ValueStopwatchTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/ValueStopwatchTest.cs
@@ -10,6 +10,18 @@ namespace Microsoft.Extensions.Internal.Test
     public class ValueStopwatchTest
     {
         [Fact]
+        public void IsActiveIsFalseForDefaultValueStopwatch()
+        {
+            Assert.False(default(ValueStopwatch).IsActive);
+        }
+
+        [Fact]
+        public void IsActiveIsTrueWhenValueStopwatchStartedWithStartNew()
+        {
+            Assert.True(ValueStopwatch.StartNew().IsActive);
+        }
+
+        [Fact]
         public void GetElapsedTimeThrowsIfValueStopwatchIsDefaultValue()
         {
             var stopwatch = default(ValueStopwatch);


### PR DESCRIPTION
I realized that there will be cases where a caller may receive a `ValueStopwatch` that may have been initialized with `default(ValueStopwatch)` and the caller may intend for the receiver to simply ignore the timestamp value. This would be the case in the following EventSource-related pattern, if the EventSource in question was disabled:

```csharp
// Returns default if the source is disabled to avoid call to Stopwatch.GetTimestamp()
var stopwatch = SomeEventSource.Log.StartEvent(...);
// Do something
SomeEventSource.Log.EndEvent(..., stopwatch);
```

In theory, the `EndEvent` could check `IsEnabled`, to determine if the stopwatch if valid, but in the unlikely (but plausible) event where the EventSource is enabled AFTER a `StartEvent` call but BEFORE the matching `EndEvent`, the EventSource could end up calling `GetElapsedTime` and getting `InvalidOperationException`.