### PR TITLE
Show name for open generic arguments

### DIFF
--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -56,10 +56,9 @@ namespace Microsoft.Extensions.Internal
             {
                 builder.Append(builtInName);
             }
-            else
+            else if (!type.IsGenericParameter)
             {
-                var name = fullName || type.IsGenericParameter ? type.FullName : type.Name;
-                builder.Append(name);
+                builder.Append(fullName ? type.FullName : type.Name);
             }
         }
 

--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Extensions.Internal
     internal class TypeNameHelper
     {
         private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string>
-            {
+        {
+            { typeof(void), "void" },
             { typeof(bool), "bool" },
             { typeof(byte), "byte" },
             { typeof(char), "char" },
@@ -26,7 +27,7 @@ namespace Microsoft.Extensions.Internal
             { typeof(uint), "uint" },
             { typeof(ulong), "ulong" },
             { typeof(ushort), "ushort" }
-            };
+        };
 
         public static string GetTypeDisplayName(object item, bool fullName = true)
         {
@@ -51,13 +52,14 @@ namespace Microsoft.Extensions.Internal
             {
                 ProcessArrayType(builder, type, fullName);
             }
-            else if (_builtInTypeNames.TryGetValue(type, out var buildInName))
+            else if (_builtInTypeNames.TryGetValue(type, out var builtInName))
             {
-                builder.Append(buildInName);
+                builder.Append(builtInName);
             }
             else
             {
-                builder.Append(fullName ? type.FullName : type.Name);
+                var name = fullName && type.FullName != null ? type.FullName : type.Name;
+                builder.Append(name);
             }
         }
 

--- a/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+++ b/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.Internal
             }
             else
             {
-                var name = fullName && type.FullName != null ? type.FullName : type.Name;
+                var name = fullName || type.IsGenericParameter ? type.FullName : type.Name;
                 builder.Append(name);
             }
         }
@@ -117,9 +117,15 @@ namespace Microsoft.Extensions.Internal
             for (var i = offset; i < length; i++)
             {
                 ProcessType(builder, genericArguments[i], fullName);
-                if (i + 1 != length)
+                if (i + 1 == length)
                 {
-                    builder.Append(", ");
+                    continue;
+                }
+
+                builder.Append(',');
+                if (!genericArguments[i + 1].IsGenericParameter)
+                {
+                    builder.Append(' ');
                 }
             }
             builder.Append('>');

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -132,20 +132,20 @@ namespace Microsoft.Extensions.Internal
 
         public static IEnumerable<object[]> GetOpenGenericsTestData()
         {
-            yield return new object[] { "List<T>", typeof(List<>), false };
-            yield return new object[] { "Dictionary<TKey, TValue>", typeof(Dictionary<,>), false };
-            yield return new object[] { "System.Collections.Generic.List<T>", typeof(List<>) };
-            yield return new object[] { "System.Collections.Generic.Dictionary<TKey, TValue>",typeof(Dictionary<,>) };
+            yield return new object[] { "List<>", typeof(List<>), false };
+            yield return new object[] { "Dictionary<,>", typeof(Dictionary<,>), false };
+            yield return new object[] { "System.Collections.Generic.List<>", typeof(List<>) };
+            yield return new object[] { "System.Collections.Generic.Dictionary<,>",typeof(Dictionary<,>) };
 
             yield return new object[]
             {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<T1>+Level2<T2>+Level3<T3>",
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<>+Level3<>",
                 typeof(Level1<>.Level2<>.Level3<>)
             };
 
             yield return new object[]
             {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<T1>+InnerNonGeneric+InnerGeneric<T2, T3>+InnerGenericLeafNode<T4>",
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<>",
                 typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>)
             };
 
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Internal
 
             yield return new object[]
             {
-                "System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<T>, TValue>",
+                "System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<>,>",
                 closedDictionaryType
             };
 
@@ -167,7 +167,7 @@ namespace Microsoft.Extensions.Internal
 
             yield return new object[]
             {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<T1>+Level2<string>+Level3<T3>",
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<string>+Level3<>",
                 closedLevelType
             };
 
@@ -178,7 +178,7 @@ namespace Microsoft.Extensions.Internal
 
             yield return new object[]
             {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<T1>+InnerNonGeneric+InnerGeneric<T2, T3>+InnerGenericLeafNode<bool>",
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<bool>",
                 closedInnerType
             };
         }

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -9,48 +9,77 @@ namespace Microsoft.Extensions.Internal
 {
     public class TypeNameHelperTest
     {
-        [Fact]
-        public void Can_pretty_print_CLR_full_name()
+        public static IEnumerable<object[]> GetFullTypeNamesTestData()
         {
             // Predefined Types
-            Assert.Equal("int",
-                TypeNameHelper.GetTypeDisplayName(typeof(int)));
-            Assert.Equal("System.Collections.Generic.List<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<int>)));
-            Assert.Equal("System.Collections.Generic.Dictionary<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, string>)));
-            Assert.Equal("System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, List<string>>)));
-            Assert.Equal("System.Collections.Generic.List<System.Collections.Generic.List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<List<string>>)));
+            yield return new object[] { "int", typeof(int) };
+            yield return new object[] { "System.Collections.Generic.List<int>", typeof(List<int>) };
+            yield return new object[] { "System.Collections.Generic.Dictionary<int, string>", typeof(Dictionary<int, string>) };
+
+            yield return new object[]
+            {
+                "System.Collections.Generic.List<System.Collections.Generic.List<string>>",
+                typeof(List<List<string>>)
+            };
+
+            yield return new object[]
+            {
+                "System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>",
+                typeof(Dictionary<int, List<string>>)
+            };
 
             // Classes inside NonGeneric class
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+A",
-                TypeNameHelper.GetTypeDisplayName(typeof(A)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+B<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<int>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, string>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, B<string>>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+B<Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<B<string>>)));
+            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+A", typeof(A) };
+            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+B<int>", typeof(B<int>) };
+            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, string>", typeof(C<int, string>) };
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
+                typeof(C<int, B<string>>)
+            };
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+B<Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
+                typeof(B<B<string>>)
+            };
 
             // Classes inside Generic class
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+D",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.D)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<int>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, string>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, Outer<int>.E<string>>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<Outer<int>.E<string>>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>",
-                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>)));
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Level1<int>.Level2<bool>.Level3<int>)));
+            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+D", typeof(Outer<int>.D) };
+            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<int>", typeof(Outer<int>.E<int>) };
+            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, string>", typeof(Outer<int>.F<int, string>) };
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
+                typeof(Outer<int>.F<int, Outer<int>.E<string>>)
+            };
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
+                typeof(Outer<int>.E<Outer<int>.E<string>>)
+            };
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>",
+                typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>)
+            };
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>",
+                typeof(Level1<int>.Level2<bool>.Level3<int>)
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFullTypeNamesTestData))]
+        public void Can_pretty_print_CLR_full_name(string expected, Type type)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
         }
 
         [Theory]

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -53,46 +53,29 @@ namespace Microsoft.Extensions.Internal
                 TypeNameHelper.GetTypeDisplayName(typeof(Level1<int>.Level2<bool>.Level3<int>)));
         }
 
-        [Fact]
-        public void Can_pretty_print_CLR_name()
+        [Theory]
+        // Predefined Types
+        [InlineData("int", typeof(int))]
+        [InlineData("List<int>", typeof(List<int>))]
+        [InlineData("Dictionary<int, string>", typeof(Dictionary<int, string>))]
+        [InlineData("Dictionary<int, List<string>>", typeof(Dictionary<int, List<string>>))]
+        [InlineData("List<List<string>>", typeof(List<List<string>>))]
+        // Classes inside NonGeneric class
+        [InlineData("A", typeof(A))]
+        [InlineData("B<int>", typeof(B<int>))]
+        [InlineData("C<int, string>", typeof(C<int, string>))]
+        [InlineData("C<int, B<string>>", typeof(C<int, B<string>>))]
+        [InlineData("B<B<string>>", typeof(B<B<string>>))]
+        // Classes inside Generic class
+        [InlineData("D", typeof(Outer<int>.D))]
+        [InlineData("E<int>", typeof(Outer<int>.E<int>))]
+        [InlineData("F<int, string>", typeof(Outer<int>.F<int, string>))]
+        [InlineData("F<int, E<string>>", typeof(Outer<int>.F<int, Outer<int>.E<string>>))]
+        [InlineData("E<E<string>>", typeof(Outer<int>.E<Outer<int>.E<string>>))]
+        [InlineData("InnerGenericLeafNode<bool>", typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>))]
+        public void Can_pretty_print_CLR_name(string expected, Type type)
         {
-            // Predefined Types
-            Assert.Equal("int",
-                TypeNameHelper.GetTypeDisplayName(typeof(int), false));
-            Assert.Equal("List<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<int>), false));
-            Assert.Equal("Dictionary<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, string>), false));
-            Assert.Equal("Dictionary<int, List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<int, List<string>>), false));
-            Assert.Equal("List<List<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(List<List<string>>), false));
-
-            // Classes inside NonGeneric class
-            Assert.Equal("A",
-                TypeNameHelper.GetTypeDisplayName(typeof(A), false));
-            Assert.Equal("B<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<int>), false));
-            Assert.Equal("C<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, string>), false));
-            Assert.Equal("C<int, B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(C<int, B<string>>), false));
-            Assert.Equal("B<B<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(B<B<string>>), false));
-
-            // Classes inside Generic class
-            Assert.Equal("D",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.D), false));
-            Assert.Equal("E<int>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<int>), false));
-            Assert.Equal("F<int, string>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, string>), false));
-            Assert.Equal("F<int, E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.F<int, Outer<int>.E<string>>), false));
-            Assert.Equal("E<E<string>>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Outer<int>.E<Outer<int>.E<string>>), false));
-            Assert.Equal("InnerGenericLeafNode<bool>",
-                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>), false));
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, false));
         }
 
         [Theory]

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -9,195 +9,159 @@ namespace Microsoft.Extensions.Internal
 {
     public class TypeNameHelperTest
     {
-        public static IEnumerable<object[]> GetFullTypeNamesTestData()
-        {
-            // Predefined Types
-            yield return new object[] { "int", typeof(int) };
-            yield return new object[] { "System.Collections.Generic.List<int>", typeof(List<int>) };
-            yield return new object[] { "System.Collections.Generic.Dictionary<int, string>", typeof(Dictionary<int, string>) };
-
-            yield return new object[]
-            {
-                "System.Collections.Generic.List<System.Collections.Generic.List<string>>",
-                typeof(List<List<string>>)
-            };
-
-            yield return new object[]
-            {
-                "System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>",
-                typeof(Dictionary<int, List<string>>)
-            };
-
-            // Classes inside NonGeneric class
-            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+A", typeof(A) };
-            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+B<int>", typeof(B<int>) };
-            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, string>", typeof(C<int, string>) };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
-                typeof(C<int, B<string>>)
-            };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+B<Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>",
-                typeof(B<B<string>>)
-            };
-
-            // Classes inside Generic class
-            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+D", typeof(Outer<int>.D) };
-            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<int>", typeof(Outer<int>.E<int>) };
-            yield return new object[] { "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, string>", typeof(Outer<int>.F<int, string>) };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
-                typeof(Outer<int>.F<int, Outer<int>.E<string>>)
-            };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>",
-                typeof(Outer<int>.E<Outer<int>.E<string>>)
-            };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>",
-                typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>)
-            };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>",
-                typeof(Level1<int>.Level2<bool>.Level3<int>)
-            };
-        }
-
         [Theory]
-        [MemberData(nameof(GetFullTypeNamesTestData))]
-        public void Can_pretty_print_CLR_full_name(string expected, Type type)
+        // Predefined Types
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(List<int>), "System.Collections.Generic.List<int>")]
+        [InlineData(typeof(Dictionary<int, string>), "System.Collections.Generic.Dictionary<int, string>")]
+        [InlineData(typeof(Dictionary<int, List<string>>), "System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>")]
+        [InlineData(typeof(List<List<string>>), "System.Collections.Generic.List<System.Collections.Generic.List<string>>")]
+        // Classes inside NonGeneric class
+        [InlineData(typeof(A),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+A")]
+        [InlineData(typeof(B<int>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+B<int>")]
+        [InlineData(typeof(C<int, string>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, string>")]
+        [InlineData(typeof(B<B<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+B<Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>")]
+        [InlineData(typeof(C<int, B<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+C<int, Microsoft.Extensions.Internal.TypeNameHelperTest+B<string>>")]
+        // Classes inside Generic class
+        [InlineData(typeof(Outer<int>.D),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+D")]
+        [InlineData(typeof(Outer<int>.E<int>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<int>")]
+        [InlineData(typeof(Outer<int>.F<int, string>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, string>")]
+        [InlineData(typeof(Level1<int>.Level2<bool>.Level3<int>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>")]
+        [InlineData(typeof(Outer<int>.E<Outer<int>.E<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>")]
+        [InlineData(typeof(Outer<int>.F<int, Outer<int>.E<string>>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+F<int, Microsoft.Extensions.Internal.TypeNameHelperTest+Outer<int>+E<string>>")]
+        [InlineData(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>),
+            "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>")]
+        public void Can_pretty_print_CLR_full_name(Type type, string expected)
         {
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
         }
 
         [Theory]
         // Predefined Types
-        [InlineData("int", typeof(int))]
-        [InlineData("List<int>", typeof(List<int>))]
-        [InlineData("Dictionary<int, string>", typeof(Dictionary<int, string>))]
-        [InlineData("Dictionary<int, List<string>>", typeof(Dictionary<int, List<string>>))]
-        [InlineData("List<List<string>>", typeof(List<List<string>>))]
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(List<int>), "List<int>")]
+        [InlineData(typeof(Dictionary<int, string>), "Dictionary<int, string>")]
+        [InlineData(typeof(Dictionary<int, List<string>>), "Dictionary<int, List<string>>")]
+        [InlineData(typeof(List<List<string>>), "List<List<string>>")]
         // Classes inside NonGeneric class
-        [InlineData("A", typeof(A))]
-        [InlineData("B<int>", typeof(B<int>))]
-        [InlineData("C<int, string>", typeof(C<int, string>))]
-        [InlineData("C<int, B<string>>", typeof(C<int, B<string>>))]
-        [InlineData("B<B<string>>", typeof(B<B<string>>))]
+        [InlineData(typeof(A), "A")]
+        [InlineData(typeof(B<int>), "B<int>")]
+        [InlineData(typeof(C<int, string>), "C<int, string>")]
+        [InlineData(typeof(C<int, B<string>>), "C<int, B<string>>")]
+        [InlineData(typeof(B<B<string>>), "B<B<string>>")]
         // Classes inside Generic class
-        [InlineData("D", typeof(Outer<int>.D))]
-        [InlineData("E<int>", typeof(Outer<int>.E<int>))]
-        [InlineData("F<int, string>", typeof(Outer<int>.F<int, string>))]
-        [InlineData("F<int, E<string>>", typeof(Outer<int>.F<int, Outer<int>.E<string>>))]
-        [InlineData("E<E<string>>", typeof(Outer<int>.E<Outer<int>.E<string>>))]
-        [InlineData("InnerGenericLeafNode<bool>", typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>))]
-        public void Can_pretty_print_CLR_name(string expected, Type type)
+        [InlineData(typeof(Outer<int>.D), "D")]
+        [InlineData(typeof(Outer<int>.E<int>), "E<int>")]
+        [InlineData(typeof(Outer<int>.F<int, string>), "F<int, string>")]
+        [InlineData(typeof(Outer<int>.F<int, Outer<int>.E<string>>), "F<int, E<string>>")]
+        [InlineData(typeof(Outer<int>.E<Outer<int>.E<string>>), "E<E<string>>")]
+        [InlineData(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>), "InnerGenericLeafNode<bool>")]
+        public void Can_pretty_print_CLR_name(Type type, string expected)
         {
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, false));
         }
 
         [Theory]
-        [InlineData("void", typeof(void))]
-        [InlineData("bool", typeof(bool))]
-        [InlineData("byte", typeof(byte))]
-        [InlineData("char", typeof(char))]
-        [InlineData("decimal", typeof(decimal))]
-        [InlineData("double", typeof(double))]
-        [InlineData("float", typeof(float))]
-        [InlineData("int", typeof(int))]
-        [InlineData("long", typeof(long))]
-        [InlineData("object", typeof(object))]
-        [InlineData("sbyte", typeof(sbyte))]
-        [InlineData("short", typeof(short))]
-        [InlineData("string", typeof(string))]
-        [InlineData("uint", typeof(uint))]
-        [InlineData("ulong", typeof(ulong))]
-        [InlineData("ushort", typeof(ushort))]
-        public void Returns_common_name_for_built_in_types(string expected, Type type)
+        [InlineData(typeof(void), "void")]
+        [InlineData(typeof(bool), "bool")]
+        [InlineData(typeof(byte), "byte")]
+        [InlineData(typeof(char), "char")]
+        [InlineData(typeof(decimal), "decimal")]
+        [InlineData(typeof(double), "double")]
+        [InlineData(typeof(float), "float")]
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(long), "long")]
+        [InlineData(typeof(object), "object")]
+        [InlineData(typeof(sbyte), "sbyte")]
+        [InlineData(typeof(short), "short")]
+        [InlineData(typeof(string), "string")]
+        [InlineData(typeof(uint), "uint")]
+        [InlineData(typeof(ulong), "ulong")]
+        [InlineData(typeof(ushort), "ushort")]
+        public void Returns_common_name_for_built_in_types(Type type, string expected)
         {
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
         }
 
         [Theory]
-        [InlineData("int[]", typeof(int[]))]
-        [InlineData("string[][]", typeof(string[][]))]
-        [InlineData("int[,]", typeof(int[,]))]
-        [InlineData("bool[,,,]", typeof(bool[,,,]))]
-        [InlineData("Microsoft.Extensions.Internal.TypeNameHelperTest+A[,][,,]", typeof(A[,][,,]))]
-        [InlineData("System.Collections.Generic.List<int[,][,,]>", typeof(List<int[,][,,]>))]
-        [InlineData("List<int[,,][,]>[,][,,]", typeof(List<int[,,][,]>[,][,,]), false)]
-        public void Can_pretty_print_array_name(string expected, Type type, bool fullName = true)
+        [InlineData(typeof(int[]), true, "int[]")]
+        [InlineData(typeof(string[][]), true, "string[][]")]
+        [InlineData(typeof(int[,]), true, "int[,]")]
+        [InlineData(typeof(bool[,,,]), true, "bool[,,,]")]
+        [InlineData(typeof(A[,][,,]), true, "Microsoft.Extensions.Internal.TypeNameHelperTest+A[,][,,]")]
+        [InlineData(typeof(List<int[,][,,]>), true, "System.Collections.Generic.List<int[,][,,]>")]
+        [InlineData(typeof(List<int[,,][,]>[,][,,]), false, "List<int[,,][,]>[,][,,]")]
+        public void Can_pretty_print_array_name(Type type, bool fullName, string expected)
         {
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
         }
 
-        public static IEnumerable<object[]> GetOpenGenericsTestData()
+        public static TheoryData GetOpenGenericsTestData()
         {
-            yield return new object[] { "List<>", typeof(List<>), false };
-            yield return new object[] { "Dictionary<,>", typeof(Dictionary<,>), false };
-            yield return new object[] { "System.Collections.Generic.List<>", typeof(List<>) };
-            yield return new object[] { "System.Collections.Generic.Dictionary<,>",typeof(Dictionary<,>) };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<>+Level3<>",
-                typeof(Level1<>.Level2<>.Level3<>)
-            };
-
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<>",
-                typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>)
-            };
-
             var openDictionaryType = typeof(Dictionary<,>);
             var genArgsDictionary = openDictionaryType.GetGenericArguments();
             genArgsDictionary[0] = typeof(B<>);
             var closedDictionaryType = openDictionaryType.MakeGenericType(genArgsDictionary);
-
-            yield return new object[]
-            {
-                "System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<>,>",
-                closedDictionaryType
-            };
 
             var openLevelType = typeof(Level1<>.Level2<>.Level3<>);
             var genArgsLevel = openLevelType.GetGenericArguments();
             genArgsLevel[1] = typeof(string);
             var closedLevelType = openLevelType.MakeGenericType(genArgsLevel);
 
-            yield return new object[]
-            {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<string>+Level3<>",
-                closedLevelType
-            };
-
             var openInnerType = typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>);
             var genArgsInnerType = openInnerType.GetGenericArguments();
             genArgsInnerType[3] = typeof(bool);
             var closedInnerType = openInnerType.MakeGenericType(genArgsInnerType);
 
-            yield return new object[]
+            return new TheoryData<Type, bool, string>
             {
-                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<bool>",
-                closedInnerType
+                { typeof(List<>), false, "List<>" },
+                { typeof(Dictionary<,>), false , "Dictionary<,>" },
+                { typeof(List<>), true , "System.Collections.Generic.List<>" },
+                { typeof(Dictionary<,>), true , "System.Collections.Generic.Dictionary<,>" },
+                { typeof(Level1<>.Level2<>.Level3<>), true, "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<>+Level3<>" },
+                {
+                    typeof(PartiallyClosedGeneric<>).BaseType,
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+C<, int>"
+                },
+                {
+                    typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>),
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<>"
+                },
+                {
+                    closedDictionaryType,
+                    true,
+                    "System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<>,>"
+                },
+                {
+                    closedLevelType,
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<>+Level2<string>+Level3<>"
+                },
+                {
+                    closedInnerType,
+                    true,
+                    "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<bool>"
+                }
             };
         }
 
         [Theory]
         [MemberData(nameof(GetOpenGenericsTestData))]
-        public void Can_pretty_print_open_generics(string expected, Type type, bool fullName = true)
+        public void Can_pretty_print_open_generics(Type type, bool fullName, string expected)
         {
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
         }
@@ -207,6 +171,8 @@ namespace Microsoft.Extensions.Internal
         private class B<T> { }
 
         private class C<T1, T2> { }
+
+        private class PartiallyClosedGeneric<T> : C<T, int> { }
 
         private class Outer<T>
         {

--- a/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
+++ b/test/Microsoft.Extensions.Internal.Test/TypeNameHelperTest.cs
@@ -130,40 +130,64 @@ namespace Microsoft.Extensions.Internal
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
         }
 
-        [Fact]
-        public void Can_pretty_print_open_generics()
+        public static IEnumerable<object[]> GetOpenGenericsTestData()
         {
-            Assert.Equal("List<T>", TypeNameHelper.GetTypeDisplayName(typeof(List<>), false));
-            Assert.Equal("Dictionary<TKey, TValue>", TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<,>), false));
-            Assert.Equal("System.Collections.Generic.List<T>", TypeNameHelper.GetTypeDisplayName(typeof(List<>)));
-            Assert.Equal("System.Collections.Generic.Dictionary<TKey, TValue>", TypeNameHelper.GetTypeDisplayName(typeof(Dictionary<,>)));
+            yield return new object[] { "List<T>", typeof(List<>), false };
+            yield return new object[] { "Dictionary<TKey, TValue>", typeof(Dictionary<,>), false };
+            yield return new object[] { "System.Collections.Generic.List<T>", typeof(List<>) };
+            yield return new object[] { "System.Collections.Generic.Dictionary<TKey, TValue>",typeof(Dictionary<,>) };
 
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<T1>+Level2<T2>+Level3<T3>",
-                TypeNameHelper.GetTypeDisplayName(typeof(Level1<>.Level2<>.Level3<>)));
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<T1>+Level2<T2>+Level3<T3>",
+                typeof(Level1<>.Level2<>.Level3<>)
+            };
 
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<T1>+InnerNonGeneric+InnerGeneric<T2, T3>+InnerGenericLeafNode<T4>",
-                TypeNameHelper.GetTypeDisplayName(typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>)));
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<T1>+InnerNonGeneric+InnerGeneric<T2, T3>+InnerGenericLeafNode<T4>",
+                typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>)
+            };
 
             var openDictionaryType = typeof(Dictionary<,>);
             var genArgsDictionary = openDictionaryType.GetGenericArguments();
             genArgsDictionary[0] = typeof(B<>);
             var closedDictionaryType = openDictionaryType.MakeGenericType(genArgsDictionary);
-            Assert.Equal("System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<T>, TValue>",
-                TypeNameHelper.GetTypeDisplayName(closedDictionaryType));
+
+            yield return new object[]
+            {
+                "System.Collections.Generic.Dictionary<Microsoft.Extensions.Internal.TypeNameHelperTest+B<T>, TValue>",
+                closedDictionaryType
+            };
 
             var openLevelType = typeof(Level1<>.Level2<>.Level3<>);
             var genArgsLevel = openLevelType.GetGenericArguments();
             genArgsLevel[1] = typeof(string);
             var closedLevelType = openLevelType.MakeGenericType(genArgsLevel);
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<T1>+Level2<string>+Level3<T3>",
-                TypeNameHelper.GetTypeDisplayName(closedLevelType));
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+Level1<T1>+Level2<string>+Level3<T3>",
+                closedLevelType
+            };
 
             var openInnerType = typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>);
             var genArgsInnerType = openInnerType.GetGenericArguments();
             genArgsInnerType[3] = typeof(bool);
             var closedInnerType = openInnerType.MakeGenericType(genArgsInnerType);
-            Assert.Equal("Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<T1>+InnerNonGeneric+InnerGeneric<T2, T3>+InnerGenericLeafNode<bool>",
-                TypeNameHelper.GetTypeDisplayName(closedInnerType));
+
+            yield return new object[]
+            {
+                "Microsoft.Extensions.Internal.TypeNameHelperTest+OuterGeneric<T1>+InnerNonGeneric+InnerGeneric<T2, T3>+InnerGenericLeafNode<bool>",
+                closedInnerType
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetOpenGenericsTestData))]
+        public void Can_pretty_print_open_generics(string expected, Type type, bool fullName = true)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
         }
 
         private class A { }


### PR DESCRIPTION
- Change open generics display from `List<>` to `List<T>`.
- Add unit test for open generics.
- Add a short name for `void` type and test for it.
- Fix variable name typo.

@smitpatel could you please check if it's in line with what you offered here #278. 