### PR TITLE
Remove usage of FX_DEPS_FILE

### DIFF
--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.CommandLineUtils
         /// Finds the full filepath to the .NET Core muxer,
         /// or returns a string containing the default name of the .NET Core muxer ('dotnet').
         /// </summary>
-        /// <returns>The path or a string named 'dotnet'</returns>
+        /// <returns>The path or a string named 'dotnet'.</returns>
         public static string MuxerPathOrDefault()
             => MuxerPath ?? MuxerName;
 
@@ -50,32 +50,8 @@ namespace Microsoft.Extensions.CommandLineUtils
             {
                 return mainModule.FileName;
             }
-
-            // if Process.MainModule is not available or it does not equal "dotnet(.exe)?", fallback to navigating to the muxer
-            // by using the location of the shared framework
-
-            var fxDepsFile = AppContext.GetData("FX_DEPS_FILE") as string;
-
-            if (string.IsNullOrEmpty(fxDepsFile))
-            {
-                return null;
-            }
-
-            var muxerDir = new FileInfo(fxDepsFile) // Microsoft.NETCore.App.deps.json
-                .Directory? // (version)
-                .Parent? // Microsoft.NETCore.App
-                .Parent? // shared
-                .Parent; // DOTNET_HOME
-
-            if (muxerDir == null)
-            {
-                return null;
-            }
-
-            var muxer = Path.Combine(muxerDir.FullName, fileName);
-            return File.Exists(muxer)
-                ? muxer
-                : null;
+            
+            return null;
         }
     }
 }


### PR DESCRIPTION
Using FX_DEPS_FILE to find dotnet.exe can give you the wrong muxer file when a newer patch is installed to the global dotnet location than the one installed into the folder containing process.mainmodule.

```
C:\Users\namc\.dotnet\dotnet.exe          <---- process.mainmodule
C:\Users\namc\.dotnet\shared\Microsoft.NETCore.App\2.0.0

C:\Program Files\dotnet\dotnet.exe       <----- the one found via FX_DEPS_FILE
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3