### PR TITLE
StringSegment better code for Indexer and Equals

### DIFF
--- a/src/Microsoft.Extensions.Primitives/StringSegment.cs
+++ b/src/Microsoft.Extensions.Primitives/StringSegment.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 if ((uint)index >= (uint)Length)
                 {
-                    ThrowHelper.ThrowIndexOutOfRangeException();
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
                 }
 
                 return Buffer[Offset + index];

--- a/src/Microsoft.Extensions.Primitives/StringSegment.cs
+++ b/src/Microsoft.Extensions.Primitives/StringSegment.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Extensions.Primitives
         {
             get
             {
-                if (index < 0 || (uint)index >= (uint)Length)
+                if ((uint)index >= (uint)Length)
                 {
                     throw new IndexOutOfRangeException();
                 }

--- a/src/Microsoft.Extensions.Primitives/StringSegment.cs
+++ b/src/Microsoft.Extensions.Primitives/StringSegment.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.Primitives
                 return false;
             }
 
-            return obj is StringSegment && Equals((StringSegment)obj);
+            return obj is StringSegment segment && Equals(segment);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Primitives/StringSegment.cs
+++ b/src/Microsoft.Extensions.Primitives/StringSegment.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 if ((uint)index >= (uint)Length)
                 {
-                    throw new IndexOutOfRangeException();
+                    ThrowHelper.ThrowIndexOutOfRangeException();
                 }
 
                 return Buffer[Offset + index];

--- a/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
+++ b/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Extensions.Primitives
             throw new ArgumentOutOfRangeException(GetArgumentName(argument));
         }
 
+        internal static void ThrowIndexOutOfRangeException()
+        {
+            throw new IndexOutOfRangeException();
+        }
+
         internal static void ThrowArgumentException(ExceptionResource resource)
         {
             throw new ArgumentException(GetResourceText(resource));

--- a/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
+++ b/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
@@ -18,11 +18,6 @@ namespace Microsoft.Extensions.Primitives
             throw new ArgumentOutOfRangeException(GetArgumentName(argument));
         }
 
-        internal static void ThrowIndexOutOfRangeException()
-        {
-            throw new IndexOutOfRangeException();
-        }
-
         internal static void ThrowArgumentException(ExceptionResource resource)
         {
             throw new ArgumentException(GetResourceText(resource));
@@ -72,7 +67,8 @@ namespace Microsoft.Extensions.Primitives
         length,
         text,
         start,
-        count
+        count,
+        index
     }
 
     internal enum ExceptionResource

--- a/test/Microsoft.Extensions.Primitives.Tests/StringSegmentTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/StringSegmentTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Extensions.Primitives
         {
             var segment = new StringSegment(value, offset, length);
 
-            Assert.Throws<IndexOutOfRangeException>(() => segment[index]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => segment[index]);
         }
 
         public static TheoryData<string, StringComparison, bool> EndsWithData


### PR DESCRIPTION
### Indexer

`if (index < 0 || (uint)index >= (uint)Length)` the first part is already covered by the second part, so it was removed.

`ThrowHelper` is used for throwing the exception, so making the indexer more inlineable.

### Equals

The cast was avoided due to new language features.

### Side note

Although I assume that _StringSegment_ will be replaced by something based on _Span_ there should be good code until this replacement actually happens.
  