### PR TITLE
remove System.Runtime.CompilerServices.Unsafe dependency from Microsoft.Extensions.Primitives.dll

### DIFF
--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.Primitives
             Append(segment.Buffer, segment.Offset, segment.Length);
         }
 
-        public unsafe void Append(string s, int offset, int count)
+        public void Append(string s, int offset, int count)
         {
             if (s == null)
             {
@@ -65,11 +65,10 @@ namespace Microsoft.Extensions.Primitives
             }
 
             EnsureCapacity(count);
-            fixed (char* destination = _value)
-            fixed (char* source = s)
+            int to = offset + count;
+            for (int i = offset; i < to; i++)
             {
-                Unsafe.CopyBlockUnaligned(destination + _offset, source + offset, (uint)count * 2);
-                _offset += count;
+                this.Append(s[i]);
             }
         }
 

--- a/src/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.csproj
+++ b/src/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.csproj
@@ -16,8 +16,4 @@ Microsoft.Extensions.Primitives.StringSegment</Description>
     <Compile Include="..\..\shared\Microsoft.Extensions.HashCodeCombiner.Sources\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I found bug and fixed it.
The bug is: System.Runtime.CompilerServices.Unsafe isn't supported in current version Xamarin.Mac v4.x.x.x (and probably, Mono v4.5 and later), which supports netstandard2.0. So lot of packages, which require this library as dependency or sub-dependency are not-runnable at those platforms (but still compilable). As example, have a look at [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite)

Current fix make those bunch of packages usable with Xamarin.Mac and Mono.


-----

below you may see piece of output of application which uses package [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite)


...
Loaded assembly: /Users/testuser/Projects/exampleapplication/exampleapplication.Mac/bin/Debug/exampleapplication.app/Contents/MonoBundle/Microsoft.Extensions.Primitives.dll [External]
Could not find `System.Runtime.CompilerServices.Unsafe` referenced by assembly `Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60`.
Could not find `System.Runtime.CompilerServices.Unsafe` referenced by assembly `Microsoft.Extensions.Caching.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60`.
Could not find `System.Runtime.CompilerServices.Unsafe` referenced by assembly `Microsoft.EntityFrameworkCore, Version=2.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60`.
Could not find `System.Runtime.CompilerServices.Unsafe` referenced by assembly `exampleapplication, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null`.