### PR TITLE
InplaceStringBuilder: better performance

### DIFF
--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -77,6 +77,30 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void Append(char c)
+        {
+            if (_offset >= Capacity)
+            {
+                ThrowNotEnoughCapacity(1);
+            }
+
+            fixed (char* destination = _value)
+            {
+                destination[_offset++] = c;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (Capacity != _offset)
+            {
+                ThrowCapacityNotUsed();
+            }
+
+            return _value;
+        }
+
         private void ThrowValidationError(string value, int offset, int count)
         {
             if (value == null)
@@ -95,33 +119,9 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Append(char c)
-        {
-            if (_offset >= Capacity)
-            {
-                ThrowNotEnoughCapacity(1);
-            }
-
-            fixed (char* destination = _value)
-            {
-                destination[_offset++] = c;
-            }
-        }
-
         private void ThrowNotEnoughCapacity(int length)
         {
             throw new InvalidOperationException($"Not enough capacity to write '{length}' characters, only '{Capacity - _offset}' left.");
-        }
-
-        public override string ToString()
-        {
-            if (Capacity != _offset)
-            {
-                ThrowCapacityNotUsed();
-            }
-
-            return _value;
         }
 
         private void ThrowCapacityNotUsed()

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Primitives
     public struct InplaceStringBuilder
     {
         private int _offset;
+        private int _capacity;
         private string _value;
 
         public InplaceStringBuilder(int capacity) : this()
@@ -20,12 +21,12 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
             }
 
-            _value = new string('\0', capacity);
+            _capacity = capacity;
         }
 
         public int Capacity
         {
-            get => _value?.Length ?? 0;
+            get => _capacity;
             set
             {
                 if (value < 0)
@@ -39,7 +40,7 @@ namespace Microsoft.Extensions.Primitives
                     ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Capacity_CannotChangeAfterWriteStarted);
                 }
 
-                _value = new string('\0', value);
+                _capacity = value;
             }
         }
 
@@ -61,6 +62,8 @@ namespace Microsoft.Extensions.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void Append(string value, int offset, int count)
         {
+            EnsureValueIsInitialized();
+
             if (value == null
                 || offset < 0
                 || value.Length - offset < count
@@ -80,6 +83,8 @@ namespace Microsoft.Extensions.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void Append(char c)
         {
+            EnsureValueIsInitialized();
+
             if (_offset >= Capacity)
             {
                 ThrowNotEnoughCapacity(1);
@@ -99,6 +104,14 @@ namespace Microsoft.Extensions.Primitives
             }
 
             return _value;
+        }
+
+        private void EnsureValueIsInitialized()
+        {
+            if (_value == null)
+            {
+                _value = new string('\0', _capacity);
+            }
         }
 
         private void ThrowValidationError(string value, int offset, int count)

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Primitives
         {
             if (Capacity != _offset)
             {
-                ThrowCapacityNotUsed();
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Capacity_not_used_entirely, Capacity, _offset);
             }
 
             return _value;
@@ -134,12 +134,7 @@ namespace Microsoft.Extensions.Primitives
 
         private void ThrowNotEnoughCapacity(int length)
         {
-            throw new InvalidOperationException($"Not enough capacity to write '{length}' characters, only '{Capacity - _offset}' left.");
-        }
-
-        private void ThrowCapacityNotUsed()
-        {
-            throw new InvalidOperationException($"Entire reserved capacity was not used. Capacity: '{Capacity}', written '{_offset}'.");
+            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Not_enough_capacity, length, Capacity - _offset);
         }
     }
 }

--- a/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
+++ b/src/Microsoft.Extensions.Primitives/InplaceStringBuilder.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Primitives
 
             if (_offset >= Capacity)
             {
-                ThrowNotEnoughCapacity(1);
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Capacity_NotEnough, 1, Capacity - _offset);
             }
 
             fixed (char* destination = _value)
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Primitives
         {
             if (Capacity != _offset)
             {
-                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Capacity_not_used_entirely, Capacity, _offset);
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Capacity_NotUsedEntirely, Capacity, _offset);
             }
 
             return _value;
@@ -128,13 +128,8 @@ namespace Microsoft.Extensions.Primitives
 
             if (Capacity - _offset < count)
             {
-                ThrowNotEnoughCapacity(value.Length);
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Capacity_NotEnough, value.Length, Capacity - _offset);
             }
-        }
-
-        private void ThrowNotEnoughCapacity(int length)
-        {
-            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.Not_enough_capacity, length, Capacity - _offset);
         }
     }
 }

--- a/src/Microsoft.Extensions.Primitives/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.Primitives/Resources.Designer.cs
@@ -66,5 +66,16 @@ namespace Microsoft.Extensions.Primitives {
                 return ResourceManager.GetString("Argument_InvalidOffsetLength", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///    Looks up a localized string similar to Cannot change capacity after write started..
+        /// </summary>
+        internal static string Capacity_CannotChangeAfterWriteStarted
+        {
+            get
+            {
+                return ResourceManager.GetString("Capacity_CannotChangeAfterWriteStarted", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.Extensions.Primitives/Resources.resx
+++ b/src/Microsoft.Extensions.Primitives/Resources.resx
@@ -120,4 +120,7 @@
   <data name="Argument_InvalidOffsetLength" xml:space="preserve">
     <value>Offset and length are out of bounds for the string or length is greater than the number of characters from index to the end of the string.</value>
   </data>
+  <data name="Capacity_CannotChangeAfterWriteStarted" xml:space="preserve">
+    <value>Cannot change capacity after write started.</value>
+  </data>
 </root>

--- a/src/Microsoft.Extensions.Primitives/Resources.resx
+++ b/src/Microsoft.Extensions.Primitives/Resources.resx
@@ -123,10 +123,10 @@
   <data name="Capacity_CannotChangeAfterWriteStarted" xml:space="preserve">
     <value>Cannot change capacity after write started.</value>
   </data>
-  <data name="Capacity_not_used_entirely" xml:space="preserve">
-    <value>Entire reserved capacity was not used. Capacity: '{0}', written '{1}'.</value>
-  </data>
-  <data name="Not_enough_capacity" xml:space="preserve">
+  <data name="Capacity_NotEnough" xml:space="preserve">
     <value>Not enough capacity to write '{0}' characters, only '{1}' left.</value>
+  </data>
+  <data name="Capacity_NotUsedEntirely" xml:space="preserve">
+    <value>Entire reserved capacity was not used. Capacity: '{0}', written '{1}'.</value>
   </data>
 </root>

--- a/src/Microsoft.Extensions.Primitives/Resources.resx
+++ b/src/Microsoft.Extensions.Primitives/Resources.resx
@@ -123,4 +123,10 @@
   <data name="Capacity_CannotChangeAfterWriteStarted" xml:space="preserve">
     <value>Cannot change capacity after write started.</value>
   </data>
+  <data name="Capacity_not_used_entirely" xml:space="preserve">
+    <value>Entire reserved capacity was not used. Capacity: '{0}', written '{1}'.</value>
+  </data>
+  <data name="Not_enough_capacity" xml:space="preserve">
+    <value>Not enough capacity to write '{0}' characters, only '{1}' left.</value>
+  </data>
 </root>

--- a/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
+++ b/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
@@ -28,6 +28,13 @@ namespace Microsoft.Extensions.Primitives
             throw new InvalidOperationException(GetResourceText(resource));
         }
 
+        internal static void ThrowInvalidOperationException(ExceptionResource resource, params object[] args)
+        {
+            var message = string.Format(GetResourceText(resource), args);
+
+            throw new InvalidOperationException(message);
+        }
+
         internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
         {
             return new ArgumentNullException(GetArgumentName(argument));
@@ -81,6 +88,8 @@ namespace Microsoft.Extensions.Primitives
     internal enum ExceptionResource
     {
         Argument_InvalidOffsetLength,
-        Capacity_CannotChangeAfterWriteStarted
+        Capacity_CannotChangeAfterWriteStarted,
+        Not_enough_capacity,
+        Capacity_not_used_entirely
     }
 }

--- a/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
+++ b/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Extensions.Primitives
             throw new ArgumentException(GetResourceText(resource));
         }
 
+        internal static void ThrowInvalidOperationException(ExceptionResource resource)
+        {
+            throw new InvalidOperationException(GetResourceText(resource));
+        }
+
         internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
         {
             return new ArgumentNullException(GetArgumentName(argument));
@@ -68,11 +73,14 @@ namespace Microsoft.Extensions.Primitives
         text,
         start,
         count,
-        index
+        index,
+        value,
+        capacity
     }
 
     internal enum ExceptionResource
     {
-        Argument_InvalidOffsetLength
+        Argument_InvalidOffsetLength,
+        Capacity_CannotChangeAfterWriteStarted
     }
 }

--- a/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
+++ b/src/Microsoft.Extensions.Primitives/ThrowHelper.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.Primitives
     {
         Argument_InvalidOffsetLength,
         Capacity_CannotChangeAfterWriteStarted,
-        Not_enough_capacity,
-        Capacity_not_used_entirely
+        Capacity_NotEnough,
+        Capacity_NotUsedEntirely
     }
 }

--- a/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/InplaceStringBuilderTest.cs
@@ -10,6 +10,12 @@ namespace Microsoft.Extensions.Primitives
     public class InplaceStringBuilderTest
     {
         [Fact]
+        public void Ctor_ThrowsIfCapacityIsNegative()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new InplaceStringBuilder(-1));
+        }
+
+        [Fact]
         public void ToString_ReturnsStringWithAllAppendedValues()
         {
             var s1 = "123";
@@ -26,6 +32,17 @@ namespace Microsoft.Extensions.Primitives
             formatter.Append(s2, 4, 1);
             formatter.Append(seg);
             Assert.Equal("12345678901", formatter.ToString());
+        }
+
+        [Fact]
+        public void ToString_ThrowsIfCapacityNotUsed()
+        {
+            var formatter = new InplaceStringBuilder(10);
+
+            formatter.Append("abc");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.ToString());
+            Assert.Equal("Entire reserved capacity was not used. Capacity: '10', written '3'.", exception.Message);
         }
 
         [Fact]
@@ -48,12 +65,74 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        public void Append_ThrowsIfNotEnoughSpace()
+        public void Capacity_ThrowsIfNegativeValueSet()
+        {
+            var formatter = new InplaceStringBuilder(3);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => formatter.Capacity = -1);
+        }
+
+        [Fact]
+        public void Capacity_GetReturnsCorrectValue()
+        {
+            var formatter = new InplaceStringBuilder(3);
+            Assert.Equal(3, formatter.Capacity);
+
+            formatter.Capacity = 10;
+            Assert.Equal(10, formatter.Capacity);
+
+            formatter.Append("abc");
+            Assert.Equal(10, formatter.Capacity);
+        }
+
+        [Fact]
+        public void Append_ThrowsIfValueIsNull()
+        {
+            var formatter = new InplaceStringBuilder(3);
+
+            Assert.Throws<ArgumentNullException>(() => formatter.Append(null as string));
+        }
+
+        [Fact]
+        public void Append_ThrowsIfValueIsNullInOverloadWithIndex()
+        {
+            var formatter = new InplaceStringBuilder(3);
+
+            Assert.Throws<ArgumentNullException>(() => formatter.Append(null as string, 0, 3));
+        }
+
+        [Fact]
+        public void Append_ThrowsIfOffsetIsNegative()
+        {
+            var formatter = new InplaceStringBuilder(3);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => formatter.Append("abc", -1, 3));
+        }
+
+        [Fact]
+        public void Append_ThrowIfValueLenghtMinusOffsetSmallerThanCount()
+        {
+            var formatter = new InplaceStringBuilder(3);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => formatter.Append("abc", 1, 3));
+        }
+
+        [Fact]
+        public void Append_ThrowsIfNotEnoughCapacity()
         {
             var formatter = new InplaceStringBuilder(1);
 
             var exception = Assert.Throws<InvalidOperationException>(() => formatter.Append("123"));
             Assert.Equal("Not enough capacity to write '3' characters, only '1' left.", exception.Message);
+        }
+
+        [Fact]
+        public void Append_ThrowsWhenNoCapacityIsSet()
+        {
+            var formatter = new InplaceStringBuilder();
+
+            var exception = Assert.Throws<InvalidOperationException>(() => formatter.Append("123"));
+            Assert.Equal("Not enough capacity to write '3' characters, only '0' left.", exception.Message);
         }
     }
 }


### PR DESCRIPTION
# Description

* covered current behavior with tests + added some test to cover the public api
* instead of throwing exceptions directly, they are thrown via _ThrowHelper_ or private methods, thus making the code for the method smaller
* decreased the size of the struct, by removing two fields (`_capacity` and `_writing`)
* `_value` gets initialized in the ctor, potentially reinitialized in setting the _Capacity_
* made _Append_-methods to inline

A variant with `char[]` instead of `string` as `_value` was tried, but the results didn't satisfy.

# Benchmarks

## Append String, StringSegment and Char

[Benchmark-Code](https://github.com/gfoidl/Benchmarks/blob/a954945e44ec2b936076de51106b5968e9fecfd9/aspnet/Common/InplaceStringBuilder/InplaceStringBuilder/Benchmarks/AppendRealisticBenchmarks.cs)

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|                                 Method |      Mean |     Error |    StdDev | Scaled | ScaledSD |
|--------------------------------------- |----------:|----------:|----------:|-------:|---------:|
|                                Default |  74.63 ns | 1.5745 ns | 2.5426 ns |   1.00 |     0.00 |
| Default_ThrowHelper_AggressiveInlining |  42.83 ns | 0.5936 ns | 0.5262 ns |   0.57 |     0.02 |
|                    Default_ThrowHelper |  54.69 ns | 0.3238 ns | 0.2704 ns |   0.73 |     0.02 |
|                              CharArray | 178.26 ns | 1.7530 ns | 1.6397 ns |   2.39 |     0.08 |


## Append String

[Benchmark-Code](https://github.com/gfoidl/Benchmarks/blob/a954945e44ec2b936076de51106b5968e9fecfd9/aspnet/Common/InplaceStringBuilder/InplaceStringBuilder/Benchmarks/AppendStringBenchmarks.cs)

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|                                 Method |       Mean |     Error |    StdDev | Scaled | ScaledSD |
|--------------------------------------- |-----------:|----------:|----------:|-------:|---------:|
|                                Default |   453.2 ns |  8.977 ns | 14.749 ns |   1.00 |     0.00 |
| Default_ThrowHelper_AggressiveInlining |   278.1 ns |  4.503 ns |  4.212 ns |   0.61 |     0.02 |
|                    Default_ThrowHelper |   340.9 ns |  4.625 ns |  4.100 ns |   0.75 |     0.03 |
|                              CharArray | 1,451.3 ns | 19.951 ns | 16.660 ns |   3.21 |     0.11 |


## Append Char

[Benchmark-Code](https://github.com/gfoidl/Benchmarks/blob/a954945e44ec2b936076de51106b5968e9fecfd9/aspnet/Common/InplaceStringBuilder/InplaceStringBuilder/Benchmarks/AppendCharBenchmarks.cs)

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|              Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------------------- |---------:|----------:|----------:|-------:|---------:|
|             Default | 553.2 ns | 10.889 ns | 18.193 ns |   1.00 |     0.00 |
| Default_ThrowHelper | 242.9 ns |  3.939 ns |  3.684 ns |   0.44 |     0.02 |
|           CharArray | 213.0 ns |  4.288 ns |  8.158 ns |   0.39 |     0.02 |


# Discussion

## AggressiveInlining

Perf with _aggressive inling_ is a lot better than without. So I'll kept it, although the caller might get bigger in code size.

## Initialization of _value

`_value` gets initialized in the ctor, when a capacity is given. If a new capacity is set via the property, so a new string is initialized, throwing away a potential previous initialized string (_value). This simplifies the checks while appending.

The current version initialized the `_value` on its first use, so there is no throw-away even if the capacity is set by the property.

I think the "new bahavior" is it worth, though setting the capacity via ctor and later via property may be a less common approach.
Or in other words: when the capacity is set via ctor xor set via property, there is no throw-away either.

