### PR TITLE
Optimized DefaultObjectPool

### DIFF
--- a/src/Microsoft.Extensions.ObjectPool/DefaultObjectPool.cs
+++ b/src/Microsoft.Extensions.ObjectPool/DefaultObjectPool.cs
@@ -32,9 +32,7 @@ namespace Microsoft.Extensions.ObjectPool
             {
                 var type = policy.GetType();
 
-                return type.IsGenericType
-                    ? type.GetGenericTypeDefinition() == typeof(DefaultPooledObjectPolicy<>)
-                    : false;
+                return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(DefaultPooledObjectPolicy<>);
             }
         }
 
@@ -56,7 +54,7 @@ namespace Microsoft.Extensions.ObjectPool
             ObjectWrapper[] items = _items;
             T item = null;
 
-            for (int i = 0; i < items.Length; i++)
+            for (var i = 0; i < items.Length; i++)
             {
                 item = items[i];
 
@@ -85,7 +83,7 @@ namespace Microsoft.Extensions.ObjectPool
         {
             ObjectWrapper[] items = _items;
 
-            for (int i = 0; i < items.Length && Interlocked.CompareExchange(ref items[i].Element, obj, null) != null; ++i)
+            for (var i = 0; i < items.Length && Interlocked.CompareExchange(ref items[i].Element, obj, null) != null; ++i)
             {
             }
         }

--- a/src/Microsoft.Extensions.ObjectPool/DefaultObjectPool.cs
+++ b/src/Microsoft.Extensions.ObjectPool/DefaultObjectPool.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.ObjectPool
 
             if (item == null || Interlocked.CompareExchange(ref _firstItem, null, item) != item)
             {
-                item = this.GetViaScan();
+                item = GetViaScan();
             }
 
             return item;
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.ObjectPool
             {
                 if (_firstItem != null || Interlocked.CompareExchange(ref _firstItem, obj, null) != null)
                 {
-                    this.ReturnViaScan(obj);
+                    ReturnViaScan(obj);
                 }
             }
         }

--- a/src/Microsoft.Extensions.ObjectPool/DefaultPooledObjectPolicy.cs
+++ b/src/Microsoft.Extensions.ObjectPool/DefaultPooledObjectPolicy.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Extensions.ObjectPool
             return new T();
         }
 
+        // DefaultObjectPool<T> doesn't call 'Return' for the default policy.
+        // So take care adding any logic to this method, as it might require changes elsewhere.
         public bool Return(T obj)
         {
             return true;


### PR DESCRIPTION
# Description

* added an `ObjectWrapper` to avoid the runtime check due to array covariance (for reference types)
* `_firstItem` is stored as field for fast access
* elminated bound checks on array access
* shortcut for `DefaultPooledObjectPolicy<T>.Return`
* tried to get good _asm_ from the JIT

# Benchmarks

## "Realisitic Usage"

[Benchmark-Code](https://github.com/gfoidl/Benchmarks/blob/40484cbfd1b8c00fe23e0d811752fa1778270250/aspnet/Common/ObjectPool/ObjectPool/Benchmarks/HalfFullPoolBenchmarks.cs)

In this benchmark half of the pool items are used, then objects are retrieved until the pool is empty, all items are returned, so the pool is full and the half of the items are retrieved again.

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|                 Method |     Mean |     Error |    StdDev | Scaled |
|----------------------- |---------:|----------:|----------:|-------:|
|                Default | 1.973 us | 0.0135 us | 0.0126 us |   1.00 |
|   New_wo_ObjectWrapper | 1.708 us | 0.0121 us | 0.0113 us |   0.87 |
| New_with_ObjectWrapper | 1.384 us | 0.0228 us | 0.0214 us |   0.70 |


## Full ObjectPool

[Benchmark-Code](https://github.com/gfoidl/Benchmarks/blob/40484cbfd1b8c00fe23e0d811752fa1778270250/aspnet/Common/ObjectPool/ObjectPool/Benchmarks/FullPoolBenchmarks.cs)

This benchmark covers the case that the pool is full, a object is retrieved and then returned to the pool. I.e. the "first element" is handled.

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|                 Method |     Mean |     Error |    StdDev | Scaled |
|----------------------- |---------:|----------:|----------:|-------:|
|                Default | 32.88 ns | 0.6073 ns | 0.5681 ns |   1.00 |
|   New_wo_ObjectWrapper | 19.70 ns | 0.1552 ns | 0.1452 ns |   0.60 |
| New_with_ObjectWrapper | 19.64 ns | 0.1598 ns | 0.1495 ns |   0.60 |


## Empty ObjectPool

[Benchmark-Code](https://github.com/gfoidl/Benchmarks/blob/40484cbfd1b8c00fe23e0d811752fa1778270250/aspnet/Common/ObjectPool/ObjectPool/Benchmarks/EmptyPoolBenchmarks.cs)

This benchmarks covers the case that the pool is empty and no object is returned to the pool. I.e. it goes down to _IPooledObjectPolicy.Create_.

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|                 Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|----------------------- |---------:|----------:|----------:|-------:|---------:|
|                Default | 86.67 ns | 1.7322 ns | 1.8534 ns |   1.00 |     0.00 |
|   New_wo_ObjectWrapper | 81.80 ns | 1.2659 ns | 1.1222 ns |   0.94 |     0.02 |
| New_with_ObjectWrapper | 87.29 ns | 0.6121 ns | 0.5726 ns |   1.01 |     0.02 |

## Results for linux-x64

Results for ubuntu are [here](https://github.com/gfoidl/Benchmarks/tree/40484cbfd1b8c00fe23e0d811752fa1778270250/aspnet/Common/ObjectPool/ObjectPool/results/linux-x64)