### PR TITLE
Add ObjectPool benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules/
 **/[Cc]ompiler/[Rr]esources/**/*.js
 .vscode/
 global.json
+BenchmarkDotNet.Artifacts/

--- a/Common.sln
+++ b/Common.sln
@@ -52,6 +52,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{D2D23857
 		build\repo.props = build\repo.props
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{A9A93AF9-2113-4321-AD20-51F60FF8B2BD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.ObjectPool.Performance", "benchmarks\Microsoft.Extensions.ObjectPool.Performance\Microsoft.Extensions.ObjectPool.Performance.csproj", "{7486AB7B-C22F-4CA0-91EA-D31D9443DBFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Primitives.Performance", "benchmarks\Microsoft.Extensions.Primitives.Performance\Microsoft.Extensions.Primitives.Performance.csproj", "{E180A42D-2CB3-4810-8605-1AC30250EFED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +92,14 @@ Global
 		{E1586801-D345-43C7-BC4B-9D4A83101B6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1586801-D345-43C7-BC4B-9D4A83101B6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1586801-D345-43C7-BC4B-9D4A83101B6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7486AB7B-C22F-4CA0-91EA-D31D9443DBFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7486AB7B-C22F-4CA0-91EA-D31D9443DBFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7486AB7B-C22F-4CA0-91EA-D31D9443DBFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7486AB7B-C22F-4CA0-91EA-D31D9443DBFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E180A42D-2CB3-4810-8605-1AC30250EFED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E180A42D-2CB3-4810-8605-1AC30250EFED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E180A42D-2CB3-4810-8605-1AC30250EFED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E180A42D-2CB3-4810-8605-1AC30250EFED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -98,6 +112,8 @@ Global
 		{DA1D70F4-717A-4440-B388-B5BEE670C14D} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
 		{7E6564C3-04E3-418C-B96A-463FE2906F09} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
 		{E1586801-D345-43C7-BC4B-9D4A83101B6C} = {8668B1D5-9C54-49CA-8446-18040B4C7D15}
+		{7486AB7B-C22F-4CA0-91EA-D31D9443DBFB} = {A9A93AF9-2113-4321-AD20-51F60FF8B2BD}
+		{E180A42D-2CB3-4810-8605-1AC30250EFED} = {A9A93AF9-2113-4321-AD20-51F60FF8B2BD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {371030CF-B541-4BA9-9F54-3C7563415CF1}

--- a/benchmarks/Microsoft.Extensions.ObjectPool.Performance/Microsoft.Extensions.ObjectPool.Performance.csproj
+++ b/benchmarks/Microsoft.Extensions.ObjectPool.Performance/Microsoft.Extensions.ObjectPool.Performance.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.ObjectPool\Microsoft.Extensions.ObjectPool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.AspNetCore.BenchmarkRunner.Sources\**\*.cs">
+      <Link>Shared\%(FileName)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Microsoft.Extensions.ObjectPool.Performance/ObjectPoolBenchmark.cs
+++ b/benchmarks/Microsoft.Extensions.ObjectPool.Performance/ObjectPoolBenchmark.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.Extensions.ObjectPool
+{
+    public class ObjectPoolBenchmark
+    {
+        // Based on the default pool size 
+        private readonly int PoolSize = Environment.ProcessorCount * 2;
+
+        private readonly ObjectPool<object> _emptyPool;
+        private readonly ObjectPool<object> _halfFullPool;
+        private readonly ObjectPool<object> _fullPool;
+
+        public ObjectPoolBenchmark()
+        {
+            var policy = new DefaultPooledObjectPolicy<object>();
+
+            _emptyPool = new DefaultObjectPool<object>(policy, PoolSize);
+            _halfFullPool = new DefaultObjectPool<object>(policy, PoolSize);
+            _fullPool = new DefaultObjectPool<object>(policy, PoolSize);
+
+            // Empty Pool needs no initialization, it's already empty
+
+            // Half Full Pool should have items in half of its slots
+            object item = null;
+            for (var i = 0; i < PoolSize; i++)
+            {
+                item = _halfFullPool.Get();
+            }
+
+            for (var i = 0; i < PoolSize / 2; i++)
+            {
+                _halfFullPool.Return(item);
+            }
+
+            // Full Pool should have items in all of it's slots
+            for (var i = 0; i < PoolSize; i++)
+            {
+                item = _fullPool.Get();
+            }
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                _fullPool.Return(item);
+            }
+        }
+
+        // This case tests the path that causes a new object to be created.
+        [Benchmark]
+        public void Get_WithEmptyPool()
+        {
+            var pool = _emptyPool;
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                var item = pool.Get();
+            }
+        }
+
+        // This case highlights the expected main usage of the object pool
+        [Benchmark]
+        public void GetAndReturn_WithPoolHalfFull()
+        {
+            var pool = _halfFullPool;
+
+            object item = null;
+            for (var i = 0; i < PoolSize / 2; i++)
+            {
+                item = pool.Get();
+            }
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                pool.Return(item);
+            }
+
+            for (var i = 0; i < PoolSize / 2; i++)
+            {
+                item = pool.Get();
+            }
+        }
+
+        // This case highlights a 'first item' optimization by getting and returning only one item from the pool
+        [Benchmark]
+        public void GetAndReturn_WithFullPool()
+        {
+            var pool = _fullPool;
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                var item = pool.Get();
+                pool.Return(item);
+            }
+        }
+    }
+}

--- a/benchmarks/Microsoft.Extensions.ObjectPool.Performance/Properties/AssemblyInfo.cs
+++ b/benchmarks/Microsoft.Extensions.ObjectPool.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/benchmarks/Microsoft.Extensions.Primitives.Performance/Microsoft.Extensions.Primitives.Performance.csproj
+++ b/benchmarks/Microsoft.Extensions.Primitives.Performance/Microsoft.Extensions.Primitives.Performance.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.Primitives\Microsoft.Extensions.Primitives.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.AspNetCore.BenchmarkRunner.Sources\**\*.cs">
+      <Link>Shared\%(FileName)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,12 +3,14 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
+    <BenchmarkDotNetPackageVersion>0.10.11</BenchmarkDotNetPackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview2-15707</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26130-04</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
+    <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.6.0-preview2-26126-03</SystemReflectionMetadataPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>4.5.0-preview2-26130-01</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>4.5.0-preview2-26130-01</SystemSecurityCryptographyCngPackageVersion>

--- a/build/repo.props
+++ b/build/repo.props
@@ -2,6 +2,10 @@
   <Import Project="dependencies.props" />
 
   <PropertyGroup>
+    <EnableBenchmarkValidation>true</EnableBenchmarkValidation>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
     <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
   </PropertyGroup>


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.11, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Processor=Intel Xeon CPU E5620 2.40GHz, ProcessorCount=8
Frequency=2337888 Hz, Resolution=427.7365 ns, Timer=TSC
.NET Core SDK=2.1.300-preview2-008173
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  Job-JIDFNJ : .NET Core 2.1.0-preview2-26130-04 (Framework 4.6.26130.05), 64bit RyuJIT

RemoveOutliers=False  Runtime=Core  Server=True  
Toolchain=.NET Core 2.1  LaunchCount=3  RunStrategy=Throughput  
TargetCount=10  WarmupCount=5  

```
|                        Method |       Mean |    Error |    StdDev |        Op/s | Allocated |
|------------------------------ |-----------:|---------:|----------:|------------:|----------:|
|             Get_WithEmptyPool | 2,475.4 ns | 83.18 ns | 124.50 ns |   403,977.4 |     384 B |
| GetAndReturn_WithPoolHalfFull | 3,396.5 ns | 90.87 ns | 136.01 ns |   294,417.4 |       0 B |
|     GetAndReturn_WithFullPool |   786.9 ns | 17.22 ns |  25.77 ns | 1,270,879.2 |       0 B |
