### PR TITLE
DefaultObjectPool "devirtualizes" calls to IPooledObjectPolicy

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,6 +16,7 @@
     <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualstudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualstudioPackageVersion>
+    <ReflectionEmitVersion>4.3.0</ReflectionEmitVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
 </Project>

--- a/src/Microsoft.Extensions.ObjectPool/Microsoft.Extensions.ObjectPool.csproj
+++ b/src/Microsoft.Extensions.ObjectPool/Microsoft.Extensions.ObjectPool.csproj
@@ -8,4 +8,8 @@
     <PackageTags>pooling</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Extensions.ObjectPool/Microsoft.Extensions.ObjectPool.csproj
+++ b/src/Microsoft.Extensions.ObjectPool/Microsoft.Extensions.ObjectPool.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(ReflectionEmitVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Extensions.ObjectPool/PolicyCompiler.cs
+++ b/src/Microsoft.Extensions.ObjectPool/PolicyCompiler.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Microsoft.Extensions.ObjectPool
+{
+    internal ref struct PolicyCompiler<T>
+    {
+        public Func<T> CompileCreate(object owner, IPooledObjectPolicy<T> policy, string policyFieldName)
+        {
+            var (ownerType, policyField) = GetOwnerInfo(owner, policyFieldName);
+            var target = policy.GetType();
+            var createMethod = target.GetMethod(nameof(IPooledObjectPolicy<T>.Create));
+            var dm = new DynamicMethod("_Create_", typeof(T), new[] { ownerType }, ownerType);
+            var ilGen = dm.GetILGenerator();
+
+            ilGen.Emit(OpCodes.Ldarg_0);
+            ilGen.Emit(OpCodes.Ldfld, policyField);
+            ilGen.Emit(OpCodes.Call, createMethod);
+            ilGen.Emit(OpCodes.Ret);
+
+            return dm.CreateDelegate(typeof(Func<T>), owner) as Func<T>;
+        }
+
+        public Func<T, bool> CompileReturn(object owner, IPooledObjectPolicy<T> policy, string policyFieldName)
+        {
+            var (ownerType, policyField) = GetOwnerInfo(owner, policyFieldName);
+            var target = policy.GetType();
+            var returnMethod = target.GetMethod(nameof(IPooledObjectPolicy<T>.Return));
+            var dm = new DynamicMethod("_Return_", typeof(bool), new[] { ownerType, typeof(T) }, ownerType);
+            var ilGen = dm.GetILGenerator();
+
+            ilGen.Emit(OpCodes.Ldarg_0);
+            ilGen.Emit(OpCodes.Ldfld, policyField);
+            ilGen.Emit(OpCodes.Ldarg_1);
+            ilGen.Emit(OpCodes.Call, returnMethod);
+            ilGen.Emit(OpCodes.Ret);
+
+            return dm.CreateDelegate(typeof(Func<T, bool>), owner) as Func<T, bool>;
+        }
+
+        private (Type ownerType, FieldInfo policyField) GetOwnerInfo(object owner, string policyFieldName)
+        {
+            var ownerType = owner.GetType();
+            var policyField = ownerType.GetField(policyFieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+
+            return (ownerType, policyField);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.ObjectPool.Test/DefaultObjectPoolTest.cs
+++ b/test/Microsoft.Extensions.ObjectPool.Test/DefaultObjectPoolTest.cs
@@ -11,6 +11,22 @@ namespace Microsoft.Extensions.ObjectPool.Test
     public class DefaultObjectPoolTest
     {
         [Fact]
+        public void DefaultObjectPoolWithDefaultPolicy_GetAnd_ReturnObject_SameInstance()
+        {
+            // Arrange
+            var pool = new DefaultObjectPool<object>(new DefaultPooledObjectPolicy<object>());
+
+            var obj1 = pool.Get();
+            pool.Return(obj1);
+
+            // Act
+            var obj2 = pool.Get();
+
+            // Assert
+            Assert.Same(obj1, obj2);
+        }
+
+        [Fact]
         public void DefaultObjectPool_GetAndReturnObject_SameInstance()
         {
             // Arrange


### PR DESCRIPTION
Continuation from https://github.com/aspnet/Common/pull/314#discussion_r169393110

# Description

I tried several things to "devirtualize" the calls to `IPooledObjectPolicy`
* [abstract class](https://github.com/gfoidl/Benchmarks/blob/1af788adb4b444a81b071f8673edf45196c72d1d/aspnet/Common/ObjectPool/ObjectPool/DefaultObjectPool2.cs)
* [expressions](https://github.com/gfoidl/Benchmarks/blob/1af788adb4b444a81b071f8673edf45196c72d1d/aspnet/Common/ObjectPool/ObjectPool/DefaultObjectPool3.cs)
* [il code generation / dynamic methods](https://github.com/gfoidl/Benchmarks/blob/1af788adb4b444a81b071f8673edf45196c72d1d/aspnet/Common/ObjectPool/ObjectPool/DefaultObjectPool4.cs)

On this I focused on the perf of `Return`, as this is a common case.
`Create` is cold, so I didn't investigate it, although the same optimization are applied.

The above mentioned tries results in (_Default_ is the state after merging https://github.com/aspnet/Common/pull/314), done with benchmarks that use `StringBuilderPooledObjectPolicy`.
``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|        Method |     Mean |     Error |    StdDev | Scaled |
|-------------- |---------:|----------:|----------:|-------:|
|       Default | 28.11 ns | 0.2196 ns | 0.2054 ns |   1.00 |
|   NoInterface | 21.75 ns | 0.1348 ns | 0.1261 ns |   0.77 |
|   Expressions | 23.38 ns | 0.1760 ns | 0.1646 ns |   0.83 |
| DynamicMethod | 21.92 ns | 0.3097 ns | 0.2897 ns |   0.78 |

Code for [benchmark](https://github.com/gfoidl/Benchmarks/blob/1af788adb4b444a81b071f8673edf45196c72d1d/aspnet/Common/ObjectPool/ObjectPool/Benchmarks/StringBuilderFullPoolBenchmarks.cs).

For completeness the results with _Original_ before merging https://github.com/aspnet/Common/pull/314:

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|        Method |     Mean |     Error |    StdDev | Scaled |
|-------------- |---------:|----------:|----------:|-------:|
|      Original | 34.14 ns | 0.4016 ns | 0.3756 ns |   1.00 |
|       Default | 29.24 ns | 0.1374 ns | 0.1285 ns |   0.86 |
|   NoInterface | 21.92 ns | 0.2210 ns | 0.2068 ns |   0.64 |
|   Expressions | 23.43 ns | 0.1165 ns | 0.1089 ns |   0.69 |
| DynamicMethod | 21.80 ns | 0.1269 ns | 0.1187 ns |   0.64 |

# Discussion

## Abstract base class

This variant requires [an abstract base class](https://github.com/gfoidl/Benchmarks/blob/1af788adb4b444a81b071f8673edf45196c72d1d/aspnet/Common/ObjectPool/ObjectPool/PooledObjectPolicy.cs)
and to take advantage of, the _PoolProvider_-classes have to be adapted. This isn't ideal, because there may be classes out in the wild the can't be updated or this takes a lot of effort to update all classes on several places.

Therefore this variant is discontinued, although perf is super.

## Expression

Expressions compiled to delegates incur a security check at runtime, that can be clearly seen in the numbers --> discontinued.

## IL code gen

* Delegates from dynamic method can be associated with an _owner_, so be security runtime check doesn't occur.
* Perf is on par with the abstract class variant.
* All existing _PoolProvider_ implementations benefit from this variant without touching the implementation. This is a huge benefit, because they get the improvement for free. Therefore this variant is reflected in the code of this PR.
* The cost for creating / compiling the delegates shouldn't matter, because this is done once at initialization.

## Combination of abstract class and IL code gen

As prototype I tried a combination of the approach with abstract base class, and when the _PoolProvider_ does just implement the interface (not the base class), so per fallback IL code is generated.

Here the perf is on par with the two others, so no real win. Because of code complexity this variant is discontinued and not checked in the repo -- I just prototyped it.