### PR TITLE
Add ObjectPool benchmarks without DefaultPooledObjectPolicy

### DIFF
--- a/benchmarks/Microsoft.Extensions.ObjectPool.Performance/StringBuilderPoolBenchmark.cs
+++ b/benchmarks/Microsoft.Extensions.ObjectPool.Performance/StringBuilderPoolBenchmark.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.Extensions.ObjectPool
+{
+    public class StringBuilderPoolBenchmark
+    {
+        // Based on the default pool size 
+        private readonly int PoolSize = Environment.ProcessorCount * 2;
+
+        private readonly ObjectPool<StringBuilder> _emptyPool;
+        private readonly ObjectPool<StringBuilder> _halfFullPool;
+        private readonly ObjectPool<StringBuilder> _fullPool;
+
+        public StringBuilderPoolBenchmark()
+        {
+            var policy = new StringBuilderPooledObjectPolicy();
+
+            _emptyPool = new DefaultObjectPool<StringBuilder>(policy, PoolSize);
+            _halfFullPool = new DefaultObjectPool<StringBuilder>(policy, PoolSize);
+            _fullPool = new DefaultObjectPool<StringBuilder>(policy, PoolSize);
+
+            // Empty Pool needs no initialization, it's already empty
+
+            // Half Full Pool should have items in half of its slots
+            StringBuilder item = null;
+            for (var i = 0; i < PoolSize; i++)
+            {
+                item = _halfFullPool.Get();
+            }
+
+            for (var i = 0; i < PoolSize / 2; i++)
+            {
+                _halfFullPool.Return(item);
+            }
+
+            // Full Pool should have items in all of it's slots
+            for (var i = 0; i < PoolSize; i++)
+            {
+                item = _fullPool.Get();
+            }
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                _fullPool.Return(item);
+            }
+        }
+
+        // This case tests the path that causes a new object to be created.
+        [Benchmark]
+        public void Get_WithEmptyPool()
+        {
+            var pool = _emptyPool;
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                var item = pool.Get();
+            }
+        }
+
+        // This case highlights the expected main usage of the object pool
+        [Benchmark]
+        public void GetAndReturn_WithPoolHalfFull()
+        {
+            var pool = _halfFullPool;
+
+            StringBuilder item = null;
+            for (var i = 0; i < PoolSize / 2; i++)
+            {
+                item = pool.Get();
+            }
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                pool.Return(item);
+            }
+
+            for (var i = 0; i < PoolSize / 2; i++)
+            {
+                item = pool.Get();
+            }
+        }
+
+        // This case highlights a 'first item' optimization by getting and returning only one item from the pool
+        [Benchmark]
+        public void GetAndReturn_WithFullPool()
+        {
+            var pool = _fullPool;
+
+            for (var i = 0; i < PoolSize; i++)
+            {
+                var item = pool.Get();
+                pool.Return(item);
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/aspnet/Common/pull/315 added benchmarks for the `DefaultObjectPool` with `DefaultPooledObjectPolicy` and there the pool applies a "short-cut-optimization" for `Return`.

The `StringBuilderPooledObjectPolicy` can't apply this optimization, so a call to `Return` has to be performed. These benchmarks reflect this.

|                        Method |       Mean |     Error |    StdDev |        Op/s |  Gen 0 | Allocated |
|------------------------------ |-----------:|----------:|----------:|------------:|-------:|----------:|
|             Get_WithEmptyPool |   756.4 ns | 13.411 ns | 20.074 ns | 1,321,971.4 | 0.0796 |    4352 B |
| GetAndReturn_WithPoolHalfFull | 1,409.4 ns | 25.639 ns | 38.375 ns |   709,514.9 |      - |       0 B |
|     GetAndReturn_WithFullPool |   372.6 ns |  2.900 ns |  4.340 ns | 2,684,118.6 |      - |       0 B |
