### PR TITLE
Add StringSegment benchmarks

### DIFF
--- a/benchmarks/Microsoft.Extensions.Primitives.Performance/Properties/AssemblyInfo.cs
+++ b/benchmarks/Microsoft.Extensions.Primitives.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/benchmarks/Microsoft.Extensions.Primitives.Performance/StringSegmentBenchmark.cs
+++ b/benchmarks/Microsoft.Extensions.Primitives.Performance/StringSegmentBenchmark.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.Extensions.Primitives.Performance
+{
+    public class StringSegmentBenchmark
+    {
+        private readonly StringSegment _segment = new StringSegment("Hello world!");
+        private readonly StringSegment _trimSegment = new StringSegment("   Hello world!   ");
+        private readonly object _boxedSegment;
+        private readonly char[] _indexOfAnyChars = { 'w', 'l' };
+
+        public StringSegmentBenchmark()
+        {
+            _boxedSegment = _segment;
+        }
+
+        [Benchmark]
+        public StringSegment Ctor_String()
+        {
+            return new StringSegment("Hello world!");
+        }
+
+        [Benchmark]
+        public string GetValue() => _segment.Value;
+
+        [Benchmark]
+        public char Indexer() => _segment[3];
+
+        [Benchmark]
+        public bool Equals_Object_Invalid() => _segment.Equals(null as object);
+
+        [Benchmark]
+        public bool Equals_Object_Valid() => _segment.Equals(_boxedSegment);
+
+        [Benchmark]
+        public bool Equals_Valid() => _segment.Equals(_segment);
+
+        [Benchmark]
+        public bool Equals_String() => _segment.Equals("Hello world!");
+
+        [Benchmark]
+        public override int GetHashCode() => _segment.GetHashCode();
+
+        [Benchmark]
+        public bool StartsWith() => _segment.StartsWith("Hel", StringComparison.Ordinal);
+
+        [Benchmark]
+        public bool EndsWith() => _segment.EndsWith("ld!", StringComparison.Ordinal);
+
+        [Benchmark]
+        public string SubString() => _segment.Substring(3, 2);
+
+        [Benchmark]
+        public StringSegment SubSegment() => _segment.Subsegment(3, 2);
+
+        [Benchmark]
+        public int IndexOf() => _segment.IndexOf(' ', 1, 7);
+
+        [Benchmark]
+        public int IndexOfAny() => _segment.IndexOfAny(_indexOfAnyChars, 1, 7);
+
+        [Benchmark]
+        public int LastIndexOf() => _segment.LastIndexOf('l');
+
+        [Benchmark]
+        public StringSegment Trim() => _trimSegment.Trim();
+
+        [Benchmark]
+        public StringSegment TrimStart() => _trimSegment.TrimStart();
+
+        [Benchmark]
+        public StringSegment TrimEnd() => _trimSegment.TrimEnd();
+    }
+}

--- a/benchmarks/Microsoft.Extensions.Primitives.Performance/StringSegmentBenchmark.cs
+++ b/benchmarks/Microsoft.Extensions.Primitives.Performance/StringSegmentBenchmark.cs
@@ -7,7 +7,8 @@ namespace Microsoft.Extensions.Primitives.Performance
     public class StringSegmentBenchmark
     {
         private readonly StringSegment _segment = new StringSegment("Hello world!");
-        private readonly StringSegment _trimSegment = new StringSegment("   Hello world!   ");
+        private readonly StringSegment _largeSegment = new StringSegment("Hello, World!, Hello people! My Car Is Cool. Your Carport is blue.");
+        private readonly StringSegment _trimSegment = new StringSegment("   Hello world!    ");
         private readonly object _boxedSegment;
         private readonly char[] _indexOfAnyChars = { 'w', 'l' };
 
@@ -44,10 +45,10 @@ namespace Microsoft.Extensions.Primitives.Performance
         public override int GetHashCode() => _segment.GetHashCode();
 
         [Benchmark]
-        public bool StartsWith() => _segment.StartsWith("Hel", StringComparison.Ordinal);
+        public bool StartsWith() => _largeSegment.StartsWith("Hel", StringComparison.Ordinal);
 
         [Benchmark]
-        public bool EndsWith() => _segment.EndsWith("ld!", StringComparison.Ordinal);
+        public bool EndsWith() => _largeSegment.EndsWith("ld!", StringComparison.Ordinal);
 
         [Benchmark]
         public string SubString() => _segment.Substring(3, 2);
@@ -56,13 +57,13 @@ namespace Microsoft.Extensions.Primitives.Performance
         public StringSegment SubSegment() => _segment.Subsegment(3, 2);
 
         [Benchmark]
-        public int IndexOf() => _segment.IndexOf(' ', 1, 7);
+        public int IndexOf() => _largeSegment.IndexOf(' ', 1, 7);
 
         [Benchmark]
-        public int IndexOfAny() => _segment.IndexOfAny(_indexOfAnyChars, 1, 7);
+        public int IndexOfAny() => _largeSegment.IndexOfAny(_indexOfAnyChars, 1, 7);
 
         [Benchmark]
-        public int LastIndexOf() => _segment.LastIndexOf('l');
+        public int LastIndexOf() => _largeSegment.LastIndexOf('l');
 
         [Benchmark]
         public StringSegment Trim() => _trimSegment.Trim();


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 17.10
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
  Job-NYQHGM : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT

RemoveOutliers=False  Runtime=Core  Server=True  
Toolchain=.NET Core 2.0  LaunchCount=3  RunStrategy=Throughput  
TargetCount=10  WarmupCount=5  

```
|                Method |       Mean |     Error |    StdDev |            Op/s |  Gen 0 | Allocated |
|---------------------- |-----------:|----------:|----------:|----------------:|-------:|----------:|
|           Ctor_String |  6.1938 ns | 0.0558 ns | 0.0836 ns |   161,450,947.8 |      - |       0 B |
|              GetValue |  3.2986 ns | 0.1685 ns | 0.2522 ns |   303,154,762.2 |      - |       0 B |
|               Indexer |  0.4726 ns | 0.0452 ns | 0.0677 ns | 2,115,975,032.4 |      - |       0 B |
| Equals_Object_Invalid |  3.4613 ns | 0.0601 ns | 0.0900 ns |   288,912,359.3 |      - |       0 B |
|   Equals_Object_Valid | 11.8679 ns | 0.1978 ns | 0.2960 ns |    84,260,973.3 |      - |       0 B |
|          Equals_Valid |  6.0853 ns | 0.0787 ns | 0.1178 ns |   164,331,267.7 |      - |       0 B |
|         Equals_String |  8.1777 ns | 0.0236 ns | 0.0353 ns |   122,284,384.5 |      - |       0 B |
|           GetHashCode | 21.9225 ns | 0.0661 ns | 0.0989 ns |    45,615,211.1 |      - |       0 B |
|            StartsWith | 15.9217 ns | 0.0959 ns | 0.1436 ns |    62,807,179.4 |      - |       0 B |
|              EndsWith | 15.7556 ns | 0.0701 ns | 0.1049 ns |    63,469,480.2 |      - |       0 B |
|             SubString | 21.7661 ns | 0.1461 ns | 0.2186 ns |    45,943,104.2 | 0.0005 |      32 B |
|            SubSegment | 26.0086 ns | 0.5708 ns | 0.8544 ns |    38,448,752.4 |      - |       0 B |
|               IndexOf | 10.7048 ns | 0.2679 ns | 0.4010 ns |    93,416,223.0 |      - |       0 B |
|            IndexOfAny | 21.2379 ns | 0.5609 ns | 0.8395 ns |    47,085,709.4 |      - |       0 B |
|           LastIndexOf | 10.3372 ns | 0.3383 ns | 0.5064 ns |    96,737,556.7 |      - |       0 B |
|                  Trim | 79.6639 ns | 1.2935 ns | 1.9361 ns |    12,552,736.8 |      - |       0 B |
|             TrimStart | 42.6913 ns | 1.0775 ns | 1.6128 ns |    23,423,963.4 |      - |       0 B |
|               TrimEnd | 44.2018 ns | 0.7579 ns | 1.1344 ns |    22,623,514.0 |      - |       0 B |
