### PR TITLE
Remove defaults from Core BDN config

### DIFF
--- a/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/DefaultCoreConfig.cs
+++ b/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/DefaultCoreConfig.cs
@@ -29,12 +29,8 @@ namespace BenchmarkDotNet.Attributes
 
             Add(Job.Core
                 .With(CsProjCoreToolchain.From(NetCoreAppSettings.NetCoreApp21))
-                .WithRemoveOutliers(false)
                 .With(new GcMode { Server = true })
-                .With(RunStrategy.Throughput)
-                .WithLaunchCount(3)
-                .WithWarmupCount(5)
-                .WithTargetCount(10));
+                .With(RunStrategy.Throughput));
         }
     }
 }


### PR DESCRIPTION
Remove default values for LaunchCount, WarmupCount, TargetCount and RemoveOutliers.

They were defined not because we understood why but because we just happened to do so once upon a time in kestrel. In latest versions, BDN would make a pilot run and detect optimal run counts that would usually be lower than our predefined values resulting in faster runs without loss of precision. 