### PR TITLE
Added Span support to Webencoders

### DIFF
--- a/Common.sln
+++ b/Common.sln
@@ -71,6 +71,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Internal.AspNetCore.Analyze
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Internal.AspNetCore.Analyzers.Tests", "test\Internal.AspNetCore.Analyzers.Tests\Internal.AspNetCore.Analyzers.Tests.csproj", "{1A579BD1-A4C4-4B1B-B092-D1670DF7F239}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Internal.Benchmarks", "benchmarks\Microsoft.Extensions.Internal.Benchmarks\Microsoft.Extensions.Internal.Benchmarks.csproj", "{7EAB9B74-5E5E-4D93-BA1E-865906C50676}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +139,10 @@ Global
 		{1A579BD1-A4C4-4B1B-B092-D1670DF7F239}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A579BD1-A4C4-4B1B-B092-D1670DF7F239}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A579BD1-A4C4-4B1B-B092-D1670DF7F239}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EAB9B74-5E5E-4D93-BA1E-865906C50676}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EAB9B74-5E5E-4D93-BA1E-865906C50676}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EAB9B74-5E5E-4D93-BA1E-865906C50676}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EAB9B74-5E5E-4D93-BA1E-865906C50676}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +163,7 @@ Global
 		{B439E0C8-F892-4AC5-BBF7-63BCDAACA7A9} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
 		{FACBCBCB-D043-4AE8-A22D-A683040999DD} = {FEAA3936-5906-4383-B750-F07FE1B156C5}
 		{1A579BD1-A4C4-4B1B-B092-D1670DF7F239} = {6878D8F1-6DCE-4677-AA1A-4D14BA6D2D60}
+		{7EAB9B74-5E5E-4D93-BA1E-865906C50676} = {A9A93AF9-2113-4321-AD20-51F60FF8B2BD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {371030CF-B541-4BA9-9F54-3C7563415CF1}

--- a/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Microsoft.Extensions.Internal.Benchmarks.csproj
+++ b/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Microsoft.Extensions.Internal.Benchmarks.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.AspNetCore.BenchmarkRunner.Sources\**\*.cs">
+      <Link>Shared\%(FileName)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.Extensions.WebEncoders.Sources\**\*.cs" />
+    <EmbeddedResource Include="..\..\shared\*.Sources\**\*.resx" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Microsoft.Extensions.Internal.Benchmarks.csproj
+++ b/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Microsoft.Extensions.Internal.Benchmarks.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 

--- a/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Microsoft.Extensions.Internal.Benchmarks.csproj
+++ b/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Microsoft.Extensions.Internal.Benchmarks.csproj
@@ -6,6 +6,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Properties/AssemblyInfo.cs
+++ b/benchmarks/Microsoft.Extensions.Internal.Benchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/benchmarks/Microsoft.Extensions.Internal.Benchmarks/WebEncodersBenchmarks.cs
+++ b/benchmarks/Microsoft.Extensions.Internal.Benchmarks/WebEncodersBenchmarks.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.Extensions.Internal.Benchmarks
+{
+    public class WebEncodersBenchmarks
+    {
+        private const int ByteArraySize = 500;
+        private readonly byte[] _data;
+        private readonly string _dataEncoded;
+        private readonly byte[] _dataWithOffset;
+        private readonly string _dataWithOffsetEncoded;
+        private readonly byte[] _guid;
+        private readonly string _guidEncoded;
+
+        public WebEncodersBenchmarks()
+        {
+            var random = new Random();
+            _data = new byte[ByteArraySize];
+            random.NextBytes(_data);
+            _dataEncoded = WebEncoders.Base64UrlEncode(_data);
+
+            _dataWithOffset = new byte[3].Concat(_data).Concat(new byte[2]).ToArray();
+            _dataWithOffsetEncoded = "xx" + _dataEncoded + "yyy";
+
+            _guid = Guid.NewGuid().ToByteArray();
+            _guidEncoded = WebEncoders.Base64UrlEncode(_guid);
+        }
+
+        [Benchmark]
+        public byte[] Base64UrlDecode_Data()
+        {
+            return WebEncoders.Base64UrlDecode(_dataEncoded);
+        }
+
+        [Benchmark]
+        public byte[] Base64UrlDecode_DataWithOffset()
+        {
+            return WebEncoders.Base64UrlDecode(_dataWithOffsetEncoded, 2, _dataEncoded.Length);
+        }
+
+        [Benchmark]
+        public byte[] Base64UrlDecode_Guid()
+        {
+            return WebEncoders.Base64UrlDecode(_guidEncoded);
+        }
+
+        [Benchmark]
+        public string Base64UrlEncode_Data()
+        {
+            return WebEncoders.Base64UrlEncode(_data);
+        }
+
+        [Benchmark]
+        public string Base64UrlEncode_DataWithOffset()
+        {
+            return WebEncoders.Base64UrlEncode(_dataWithOffset, 3, _data.Length);
+        }
+
+        [Benchmark]
+        public string Base64UrlEncode_Guid()
+        {
+            return WebEncoders.Base64UrlEncode(_guid);
+        }
+
+        [Benchmark]
+        public int GetArraySizeRequiredToDecode()
+        {
+            return WebEncoders.GetArraySizeRequiredToDecode(ByteArraySize);
+        }
+
+        [Benchmark]
+        public int GetArraySizeRequiredToEncode()
+        {
+            return WebEncoders.GetArraySizeRequiredToEncode(ByteArraySize);
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/Properties/EncoderResources.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/Properties/EncoderResources.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Extensions.WebEncoders.Sources
         internal static readonly string WebEncoders_MalformedInput = "Malformed input: {0} is an invalid input length.";
 
         /// <summary>
+        /// Invalid input, that doesn't conform a base64 string.
+        /// </summary>
+        internal static readonly string WebEncoders_InvalidInput = "The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.";
+
+        /// <summary>
         /// Invalid {0}, {1} or {2} length.
         /// </summary>
         internal static string FormatWebEncoders_InvalidCountOffsetOrLength(object p0, object p1, object p2)

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/Properties/EncoderResources.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/Properties/EncoderResources.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Extensions.WebEncoders.Sources
         internal static readonly string WebEncoders_InvalidInput = "The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.";
 
         /// <summary>
+        /// Destination buffer is too small.
+        /// </summary>
+        internal static readonly string WebEncoders_DestinationTooSmall = "The destination buffer is too small.";
+
+        /// <summary>
         /// Invalid {0}, {1} or {2} length.
         /// </summary>
         internal static string FormatWebEncoders_InvalidCountOffsetOrLength(object p0, object p1, object p2)

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
@@ -32,7 +32,16 @@ namespace Microsoft.Extensions.Internal
         private const int MaxEncodedLength = int.MaxValue / 4 * 3;  // encode inflates the data by 4/3
         private static readonly byte[] EmptyBytes = new byte[0];
 
-        // TODO: XML Comment
+        /// <summary>
+        /// Decodes a base64url-encoded <paramref name="base64Url"/> into a <paramref name="data"/>.
+        /// </summary>
+        /// <param name="base64Url">A span containing the base64url-encoded input to decode.</param>
+        /// <param name="data">The base64url-decoded form of the <paramref name="base64Url"/>.</param>
+        /// <returns>The number of the bytes written to <paramref name="data"/>.</returns>
+        /// <remarks>
+        /// The input must not contain any whitespace or padding characters.
+        /// Throws <see cref="FormatException"/> if the input is malformed.
+        /// </remarks>
         public static int Base64UrlDecode(ReadOnlySpan<char> base64Url, Span<byte> data)
         {
             // Special-case empty input
@@ -66,7 +75,15 @@ namespace Microsoft.Extensions.Internal
             }
         }
 
-        // TODO: XML Comment
+        /// <summary>
+        /// Decodes a base64url-encoded <paramref name="base64Url"/>.
+        /// </summary>
+        /// <param name="base64Url">The base64url-encoded input to decode.</param>
+        /// <returns>The base64url-decoded form of the input.</returns>
+        /// <remarks>
+        /// The input must not contain any whitespace or padding characters.
+        /// Throws <see cref="FormatException"/> if the input is malformed.
+        /// </remarks>
         public static byte[] Base64UrlDecode(ReadOnlySpan<char> base64Url)
         {
             // Special-case empty input
@@ -90,7 +107,21 @@ namespace Microsoft.Extensions.Internal
             }
         }
 
-        // TODO: XML Comment
+        /// <summary>
+        /// Decode the span of UTF-8 base64url-encoded text into binary data.
+        /// </summary>
+        /// <param name="base64Url">The input span which contains UTF-8 base64url-encoded text that needs to be decoded.</param>
+        /// <param name="data">The output span which contains the result of the operation, i.e. the decoded binary data.</param>
+        /// <param name="bytesConsumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
+        /// <param name="bytesWritten">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+        /// <param name="isFinalBlock">True (default) when the input span contains the entire data to decode. 
+        /// Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+        /// <returns>It returns the OperationStatus enum values:
+        /// - Done - on successful processing of the entire input span
+        /// - DestinationTooSmall - if there is not enough space in the output span to fit the decoded input
+        /// - NeedMoreData - only if isFinalBlock is false and the input is not a multiple of 4, otherwise the partial input would be considered as InvalidData
+        /// - InvalidData - if the input contains bytes outside of the expected base 64 range, or if it contains invalid/more than two padding characters,
+        ///   or if the input is incomplete (i.e. not a multiple of 4) and isFinalBlock is true.</returns>
         public static OperationStatus Base64UrlDecode(ReadOnlySpan<byte> base64Url, Span<byte> data, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
         {
             // Special-case empty input
@@ -217,7 +248,6 @@ namespace Microsoft.Extensions.Internal
                 var output = outputBuffer.AsSpan();
 
                 // If the caller provided invalid base64 chars, they'll be caught here.
-                // TODO: try  byte-based variant
                 Convert.TryFromBase64Chars(buffer, output, out int bytesWritten);
                 return output.Slice(0, bytesWritten).ToArray();
             }
@@ -250,7 +280,12 @@ namespace Microsoft.Extensions.Internal
             return GetBufferSizeRequiredToUrlDecode(count);
         }
 
-        // TODO: XML Comment
+        /// <summary>
+        /// Encodes <paramref name="data"/> using base64url-encoding into <paramref name="base64Url"/>.
+        /// </summary>
+        /// <param name="data">The binary input to encode.</param>
+        /// <param name="base64Url">The base64url-encoded form of <paramref name="data"/>.</param>
+        /// <returns>The number of chars written to <paramref name="base64Url"/>.</returns>
         public static int Base64UrlEncode(ReadOnlySpan<byte> data, Span<char> base64Url)
         {
             // Use base64url encoding with no padding characters. See RFC 4648, Sec. 5.
@@ -285,7 +320,11 @@ namespace Microsoft.Extensions.Internal
             }
         }
 
-        // TODO: XML Comment
+        /// <summary>
+        /// Encodes <paramref name="data"/> using base64url-encoding.
+        /// </summary>
+        /// <param name="data">The binary input to encode.</param>
+        /// <returns>The base64url-encoded form of <paramref name="input"/>.</returns>
         public static unsafe string Base64UrlEncode(ReadOnlySpan<byte> data)
         {
             // Special-case empty input
@@ -309,7 +348,20 @@ namespace Microsoft.Extensions.Internal
 #endif
         }
 
-        // TODO: XML Comment
+        /// <summary>
+        /// Encode the span of binary data into UTF-8 base64url-encoded representation.
+        /// </summary>
+        /// <param name="data">The input span which contains binary data that needs to be encoded.</param>
+        /// <param name="base64Url">The output span which contains the result of the operation, i.e. the UTF-8 base64url-encoded text.</param>
+        /// <param name="bytesConsumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
+        /// <param name="bytesWritten">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+        /// <param name="isFinalBlock">True (default) when the input span contains the entire data to decode. 
+        /// Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+        /// <returns>It returns the OperationStatus enum values:
+        /// - Done - on successful processing of the entire input span
+        /// - DestinationTooSmall - if there is not enough space in the output span to fit the encoded input
+        /// - NeedMoreData - only if isFinalBlock is false, otherwise the output is padded if the input is not a multiple of 3
+        /// It does not return InvalidData since that is not possible for base 64 encoding.</returns>
         public static OperationStatus Base64UrlEncode(ReadOnlySpan<byte> data, Span<byte> base64Url, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
         {
             // Special-case empty input
@@ -332,14 +384,14 @@ namespace Microsoft.Extensions.Internal
         }
 
         /// <summary>
-        /// Encodes <paramref name="input"/> using base64url encoding.
+        /// Encodes <paramref name="input"/> using base64url-encoding.
         /// </summary>
         /// <param name="input">The binary input to encode.</param>
         /// <returns>The base64url-encoded form of <paramref name="input"/>.</returns>
         public static string Base64UrlEncode(byte[] input) => Base64UrlEncode(input, 0, input.Length);
 
         /// <summary>
-        /// Encodes <paramref name="input"/> using base64url encoding.
+        /// Encodes <paramref name="input"/> using base64url-encoding.
         /// </summary>
         /// <param name="input">The binary input to encode.</param>
         /// <param name="offset">The offset into <paramref name="input"/> at which to begin encoding.</param>
@@ -372,7 +424,7 @@ namespace Microsoft.Extensions.Internal
         }
 
         /// <summary>
-        /// Encodes <paramref name="input"/> using base64url encoding.
+        /// Encodes <paramref name="input"/> using base64url-encoding.
         /// </summary>
         /// <param name="input">The binary input to encode.</param>
         /// <param name="offset">The offset into <paramref name="input"/> at which to begin encoding.</param>

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Extensions.Internal
         /// Encodes <paramref name="data"/> using base64url-encoding.
         /// </summary>
         /// <param name="data">The binary input to encode.</param>
-        /// <returns>The base64url-encoded form of <paramref name="input"/>.</returns>
+        /// <returns>The base64url-encoded form of <paramref name="data"/>.</returns>
         public static unsafe string Base64UrlEncode(ReadOnlySpan<byte> data)
         {
             // Special-case empty input

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
@@ -646,7 +646,7 @@ namespace Microsoft.Extensions.Internal
 #if NET461
                     : new byte[base64Len];
 #else
-                    : arrayToReturnToPool = ArrayPool<byte>.Shared.Rent(base64Len);
+                    : new Span<byte>(arrayToReturnToPool = ArrayPool<byte>.Shared.Rent(base64Len), 0, base64Len);
 #endif
                 var status = Base64.EncodeToUtf8(data, base64Bytes, out int consumed, out int written);
 
@@ -1011,7 +1011,7 @@ namespace Microsoft.Extensions.Internal
                 if (Vector.IsHardwareAccelerated && (int*)n >= (int*)Vector<byte>.Count)
                 {
                     // TODO: replace with nuint once available
-                    m = (IntPtr)((int)(int*)n & ~(Vector<ushort>.Count - 1));
+                    m = (IntPtr)((int)(int*)n & ~(Vector<byte>.Count - 1));
                     for (; (int*)i < (int*)m; i += Vector<byte>.Count)
                     {
                         var bytesVec = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref input, i));

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
@@ -929,7 +929,7 @@ namespace Microsoft.Extensions.Internal
                         }
                         else
                         {
-                            throw new NotSupportedException();	// just in case new types are introduced in the future
+                            throw new NotSupportedException();  // just in case new types are introduced in the future
                         }
 
                         Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref urlEncoded, i)), vec);
@@ -1183,11 +1183,11 @@ namespace Microsoft.Extensions.Internal
                 switch (status)
                 {
                     case OperationStatus.DestinationTooSmall:
-                        return new InvalidOperationException();
+                        return new InvalidOperationException(EncoderResources.WebEncoders_DestinationTooSmall);
                     case OperationStatus.InvalidData:
                         return new FormatException(EncoderResources.WebEncoders_InvalidInput);
-                    default:                // This case won't happen.
-                        return null;
+                    default:                                // This case won't happen.
+                        throw new NotSupportedException();  // Just in case new states are introduced
                 }
             }
 

--- a/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
+++ b/shared/Microsoft.Extensions.WebEncoders.Sources/WebEncoders.cs
@@ -359,7 +359,8 @@ namespace Microsoft.Extensions.Internal
             }
 
             Span<char> base64 = stackalloc char[base64Len];
-            return Base64UrlEncodeCore(data, base64, base64Url);
+            Convert.TryToBase64Chars(data, base64, out int written);
+            return EncodingHelper.UrlEncode(base64, base64Url);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -369,7 +370,8 @@ namespace Microsoft.Extensions.Internal
             try
             {
                 var base64 = new Span<char>(arrayToReturnToPool = ArrayPool<char>.Shared.Rent(base64Len), 0, base64Len);
-                return Base64UrlEncodeCore(data, base64, base64Url);
+                Convert.TryToBase64Chars(data, base64, out int written);
+                return EncodingHelper.UrlEncode(base64, base64Url);
             }
             finally
             {
@@ -378,12 +380,6 @@ namespace Microsoft.Extensions.Internal
                     ArrayPool<char>.Shared.Return(arrayToReturnToPool);
                 }
             }
-        }
-
-        private static int Base64UrlEncodeCore(ReadOnlySpan<byte> data, Span<char> base64, Span<char> base64Url)
-        {
-            Convert.TryToBase64Chars(data, base64, out int written);
-            return EncodingHelper.UrlEncode(base64, base64Url);
         }
 #else
         private static int Base64UrlEncodeCore(ReadOnlySpan<byte> data, Span<char> base64Url, int base64Len)

--- a/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
+++ b/test/Microsoft.Extensions.Internal.Test/Microsoft.Extensions.Internal.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
+++ b/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Extensions.Internal
             char[] buffer = base64EncodedValue.ToCharArray();
 
             // Act
-            var result = WebEncoders.UrlEncodeInternal(buffer);
+            var result = WebEncoders.EncodingHelper.UrlEncodeInternal(buffer);
 
             // Assert
             for (var i = 0; i < result.Length; i++)
@@ -209,7 +209,7 @@ namespace Microsoft.Extensions.Internal
             var paddingsCharsToAdd = buffer.Length - text.Length;
 
             // Act
-            WebEncoders.UrlDecodeInternal(text.AsSpan(), buffer);
+            WebEncoders.EncodingHelper.UrlDecodeInternal(text.AsSpan(), buffer);
 
             // Assert
             for (var i = 0; i < expectedValue.Length; i++)

--- a/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
+++ b/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Extensions.Internal
             Encoding.ASCII.GetBytes(expectedValue.AsSpan(), expected);
 
             // Act
-            var result = WebEncoders.EncodingHelper.UrlEncode(bytes);
+            var result = WebEncoders.EncodingHelper.UrlEncode(bytes, bytes.Length);
 
             // Assert
             Assert.True(expected.SequenceEqual(bytes.Slice(0, result)));

--- a/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
+++ b/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Extensions.Internal
             Span<byte> result = stackalloc byte[expectedValue.Length];
 
             // Act
-            WebEncoders.EncodingHelper.UrlDecode(bytes, result);
+            WebEncoders.UrlEncoder.UrlDecode(bytes, result);
 
             // Assert
             Assert.True(expected.SequenceEqual(result));
@@ -239,7 +239,7 @@ namespace Microsoft.Extensions.Internal
             var buffer = new char[expectedValue.Length];
 
             // Act
-            WebEncoders.EncodingHelper.UrlDecode(text.AsSpan(), buffer);
+            WebEncoders.UrlEncoder.UrlDecode(text.AsSpan(), buffer);
 
             // Assert
             Assert.Equal(expectedValue, new string(buffer));
@@ -270,7 +270,7 @@ namespace Microsoft.Extensions.Internal
             Encoding.ASCII.GetBytes(expectedValue.AsSpan(), expected);
 
             // Act
-            var result = WebEncoders.EncodingHelper.UrlEncode(bytes, bytes.Length);
+            var result = WebEncoders.UrlEncoder.UrlEncode(bytes, bytes.Length);
 
             // Assert
             Assert.True(expected.SequenceEqual(bytes.Slice(0, result)));
@@ -279,7 +279,7 @@ namespace Microsoft.Extensions.Internal
             var buffer = base64EncodedValue.ToCharArray();
 
             // Act
-            var result = WebEncoders.EncodingHelper.UrlEncode(buffer, buffer);
+            var result = WebEncoders.UrlEncoder.UrlEncode(buffer, buffer);
 
             // Assert
             Assert.Equal(expectedValue.Length, result);

--- a/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
+++ b/test/Microsoft.Extensions.Internal.Test/WebEncodersTests.cs
@@ -168,6 +168,33 @@ namespace Microsoft.Extensions.Internal
 
         // Taken from https://github.com/aspnet/HttpAbstractions/pull/926
         [Theory]
+        [InlineData("", "")]
+        [InlineData("+", "-")]
+        [InlineData("/", "_")]
+        [InlineData("=", "")]
+        [InlineData("==", "")]
+        [InlineData("a+b+c+==", "a-b-c-")]
+        [InlineData("a/b/c==", "a_b_c")]
+        [InlineData("a+b/c==", "a-b_c")]
+        [InlineData("a+b/c", "a-b_c")]
+        [InlineData("abcd", "abcd")]
+        public void UrlEncodeInternal_Replaces_UrlEncodableCharacters(string base64EncodedValue, string expectedValue)
+        {
+            // Arrange
+            char[] buffer = base64EncodedValue.ToCharArray();
+
+            // Act
+            var result = WebEncoders.UrlEncodeInternal(buffer);
+
+            // Assert
+            for (var i = 0; i < result.Length; i++)
+            {
+                Assert.Equal(expectedValue[i], buffer[i]);
+            }
+        }
+
+        // Taken from https://github.com/aspnet/HttpAbstractions/pull/926
+        [Theory]
         [InlineData("_", "/===")]
         [InlineData("-", "+===")]
         [InlineData("a-b-c", "a+b+c===")]


### PR DESCRIPTION
# Description

* Fixes https://github.com/aspnet/Home/issues/2966
* added benchmark-project for `WebEncoders`
* added Span-support to the API (see section _API_) and used the Span-based methods internally
* small buffers (<= 256 bytes length) are stack allocated, larger ones rent from ArrayPool (except net461, there the large ones are heap allocated)
* vectorized the url-encoding / -decoding step
* more or less a rewrite of the class (and so it got a bit longer)
* tried to reach best perf and minimal heap allocations for netcoreapp2.1, netcoreapp2.0, and net461

Due the latter point some `#if`s are needed, so the code doesn't look as nice as it could on some places.

## API

```diff
public static byte[] Base64UrlDecode(string input)
 public static byte[] Base64UrlDecode(string input, int offset, int count)
+public static byte[] Base64UrlDecode(ReadOnlySpan<char> base64Url)
+public static int Base64UrlDecode(ReadOnlySpan<char> base64Url, Span<byte> data)
+public static OperationStatus Base64UrlDecode(ReadOnlySpan<byte> base64Url, Span<byte> data, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
 public static byte[] Base64UrlDecode(string input, int offset, char[] buffer, int bufferOffset, int count)
 public static string Base64UrlEncode(byte[] input)
 public static string Base64UrlEncode(byte[] input, int offset, int count)
+public static string Base64UrlEncode(ReadOnlySpan<byte> data)
+public static int Base64UrlEncode(ReadOnlySpan<byte> data, Span<char> base64Url)
+public static OperationStatus Base64UrlEncode(ReadOnlySpan<byte> data, Span<byte> base64Url, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
 public static int Base64UrlEncode(byte[] input, int offset, char[] output, int outputOffset, int count)
 public static int GetArraySizeRequiredToDecode(int count)
 public static int GetArraySizeRequiredToEncode(int count)
```

# Benchmarks

## Results from Benchmark-Project

### Baseline

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.300-preview3-008416
  [Host]     : .NET Core 2.1.0-preview2-26314-02 (Framework 4.6.26310.01), 64bit RyuJIT
  Job-GJOWXM : .NET Core 2.1.0-preview2-26314-02 (Framework 4.6.26310.01), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET Core 2.1  
RunStrategy=Throughput  

```
|                         Method |          Mean |       Error |      StdDev |        Median |             Op/s |  Gen 0 | Allocated |
|------------------------------- |--------------:|------------:|------------:|--------------:|-----------------:|-------:|----------:|
|           Base64UrlDecode_Data | 5,168.7843 ns | 114.5844 ns | 336.0562 ns | 5,181.8617 ns |        193,469.1 | 0.0301 |    1888 B |
| Base64UrlDecode_DataWithOffset | 5,290.3002 ns | 178.3533 ns | 525.8787 ns | 5,302.4528 ns |        189,025.2 | 0.0302 |    1888 B |
|           Base64UrlDecode_Guid |   237.9833 ns |   6.1025 ns |  17.5093 ns |   234.4482 ns |      4,201,976.3 | 0.0017 |     112 B |
|           Base64UrlEncode_Data | 3,124.1497 ns | 111.2723 ns | 109.2843 ns | 3,079.0000 ns |        320,087.1 | 0.0455 |    2720 B |
| Base64UrlEncode_DataWithOffset | 3,269.8675 ns |  86.4926 ns | 252.3030 ns | 3,197.4447 ns |        305,822.8 | 0.0455 |    2720 B |
|           Base64UrlEncode_Guid |   172.6008 ns |   5.4054 ns |  15.8531 ns |   168.7662 ns |      5,793,717.2 | 0.0024 |     144 B |
|   GetArraySizeRequiredToDecode |     6.6558 ns |   0.2717 ns |   0.8012 ns |     6.5851 ns |    150,244,480.7 |      - |       0 B |
|   GetArraySizeRequiredToEncode |     0.0377 ns |   0.0312 ns |   0.0554 ns |     0.0004 ns | 26,507,091,393.8 |      - |       0 B |

### This PR

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 16.04
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.300-preview3-008416
  [Host]     : .NET Core 2.1.0-preview2-26314-02 (Framework 4.6.26310.01), 64bit RyuJIT
  Job-MVRCXO : .NET Core 2.1.0-preview2-26314-02 (Framework 4.6.26310.01), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET Core 2.1  
RunStrategy=Throughput  

```
|                         Method |          Mean |      Error |      StdDev |        Median |             Op/s |  Gen 0 | Allocated |
|------------------------------- |--------------:|-----------:|------------:|--------------:|-----------------:|-------:|----------:|
|           Base64UrlDecode_Data | 1,293.3192 ns | 57.9273 ns | 168.0575 ns | 1,259.1617 ns |        773,204.3 | 0.0076 |     528 B |
| Base64UrlDecode_DataWithOffset | 1,335.1744 ns | 61.1991 ns | 178.5208 ns | 1,306.9594 ns |        748,965.8 | 0.0076 |     528 B |
|           Base64UrlDecode_Guid |   155.3893 ns |  5.1800 ns |  15.2734 ns |   153.4095 ns |      6,435,450.5 | 0.0005 |      40 B |
|           Base64UrlEncode_Data | 1,584.6087 ns | 13.6427 ns |  10.6513 ns | 1,580.5804 ns |        631,070.6 | 0.0228 |    1360 B |
| Base64UrlEncode_DataWithOffset | 1,621.0625 ns | 29.7223 ns |  23.2052 ns | 1,615.7145 ns |        616,879.3 | 0.0226 |    1360 B |
|           Base64UrlEncode_Guid |   160.5265 ns |  5.6154 ns |  16.5571 ns |   160.0300 ns |      6,229,501.0 | 0.0012 |      72 B |
|   GetArraySizeRequiredToDecode |     0.0530 ns |  0.0317 ns |   0.0784 ns |     0.0001 ns | 18,869,922,106.3 |      - |       0 B |
|   GetArraySizeRequiredToEncode |     0.0764 ns |  0.0409 ns |   0.0853 ns |     0.0531 ns | 13,088,763,160.8 |      - |       0 B |

### Notes

This benchmarks were run on ubuntu-x64. On win-x64 the results should be even better (see next section), but I don't have numbers, because it takes so long....

In `GetArraySizeRequiredToEncode` there is a little slow-down, but this shouldn't care.

## Individual benchmarks 

[Project for this benchmarks](https://github.com/gfoidl/Benchmarks/tree/d2f1010b8bbbbc745ae4f8222a91b2d8c08fd370/aspnet/Common/WebEncoders)

### Decode Guid

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742189 Hz, Resolution=364.6722 ns, Timer=TSC
.NET Core SDK=2.1.300-preview3-008384
  [Host] : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT
  Clr	 : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  Core	 : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT


```
|  Method |	 Job | Runtime |	 Mean |	   Error |	 StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------- |----- |-------- |---------:|---------:|---------:|-------:|---------:|-------:|----------:|
| Default |	 Clr |	   Clr | 159.8 ns | 3.171 ns | 3.525 ns |	1.00 |	   0.00 | 0.0355 |	   112 B |
|	  New |	 Clr |	   Clr | 126.4 ns | 2.110 ns | 1.973 ns |	0.79 |	   0.02 | 0.0126 |		40 B |
|		  |		 |		   |		  |			 |			|		 |			|		 |			 |
| Default | Core |	  Core | 172.6 ns | 3.249 ns | 2.880 ns |	1.00 |	   0.00 | 0.0355 |	   112 B |
|	  New | Core |	  Core | 119.0 ns | 2.292 ns | 2.032 ns |	0.69 |	   0.02 | 0.0126 |		40 B |

### Decode Data

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742189 Hz, Resolution=364.6722 ns, Timer=TSC
.NET Core SDK=2.1.300-preview3-008384
  [Host] : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT
  Clr	 : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  Core	 : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT


```
|  Method |	 Job | Runtime | DataSize |		Mean |		Error |		StdDev |   Median | Scaled | ScaledSD |	 Gen 0 | Allocated |
|-------- |----- |-------- |--------- |---------:|-----------:|-----------:|---------:|-------:|---------:|-------:|----------:|
| **Default** |	 **Clr** |	   **Clr** |	   **10** | **119.7 ns** |	**2.4100 ns** |	 **2.6787 ns** | **119.4 ns** |	  **1.00** |	 **0.00** | **0.0303** |	  **96 B** |
|	  New |	 Clr |	   Clr |	   10 | 124.7 ns |	2.5604 ns |	 3.4181 ns | 124.7 ns |	  1.04 |	 0.04 | 0.0126 |	  40 B |
|		  |		 |		   |		  |			 |			  |			   |		  |		   |		  |		   |		   |
| Default | Core |	  Core |	   10 | 131.0 ns |	2.7016 ns |	 5.6392 ns | 129.9 ns |	  1.00 |	 0.00 | 0.0303 |	  96 B |
|	  New | Core |	  Core |	   10 | 106.6 ns |	3.3803 ns |	 9.6988 ns | 103.2 ns |	  0.82 |	 0.08 | 0.0126 |	  40 B |
|		  |		 |		   |		  |			 |			  |			   |		  |		   |		  |		   |		   |
| **Default** |	 **Clr** |	   **Clr** |	   **50** | **398.0 ns** |	**7.8665 ns** |	 **9.3645 ns** | **398.5 ns** |	  **1.00** |	 **0.00** | **0.0758** |	 **240 B** |
|	  New |	 Clr |	   Clr |	   50 | 203.1 ns |	1.3501 ns |	 1.0541 ns | 202.9 ns |	  0.51 |	 0.01 | 0.0253 |	  80 B |
|		  |		 |		   |		  |			 |			  |			   |		  |		   |		  |		   |		   |
| Default | Core |	  Core |	   50 | 430.2 ns |	3.4316 ns |	 3.2099 ns | 431.0 ns |	  1.00 |	 0.00 | 0.0758 |	 240 B |
|	  New | Core |	  Core |	   50 | 132.8 ns |	0.7019 ns |	 0.6222 ns | 133.0 ns |	  0.31 |	 0.00 | 0.0253 |	  80 B |
|		  |		 |		   |		  |			 |			  |			   |		  |		   |		  |		   |		   |
| **Default** |	 **Clr** |	   **Clr** |	  **100** | **744.1 ns** | **10.4349 ns** |	 **8.7136 ns** | **742.6 ns** |	  **1.00** |	 **0.00** | **0.1345** |	 **424 B** |
|	  New |	 Clr |	   Clr |	  100 | 380.2 ns |	7.5157 ns | 12.5570 ns | 380.2 ns |	  0.51 |	 0.02 | 0.0911 |	 288 B |
|		  |		 |		   |		  |			 |			  |			   |		  |		   |		  |		   |		   |
| Default | Core |	  Core |	  100 | 866.1 ns | 15.9919 ns | 22.4184 ns | 864.3 ns |	  1.00 |	 0.00 | 0.1345 |	 424 B |
|	  New | Core |	  Core |	  100 | 277.8 ns |	5.5897 ns |	 9.9358 ns | 278.1 ns |	  0.32 |	 0.01 | 0.0405 |	 128 B |


### Encode Guid

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742189 Hz, Resolution=364.6722 ns, Timer=TSC
.NET Core SDK=2.1.300-preview3-008384
  [Host] : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT
  Clr	 : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  Core	 : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT


```
|  Method |	 Job | Runtime |	  Mean |	Error |	  StdDev | Scaled | ScaledSD |	Gen 0 | Allocated |
|-------- |----- |-------- |----------:|---------:|---------:|-------:|---------:|-------:|----------:|
| Default |	 Clr |	   Clr | 143.72 ns | 2.896 ns | 3.448 ns |	 1.00 |		0.00 | 0.0455 |		144 B |
|	  New |	 Clr |	   Clr | 123.75 ns | 2.683 ns | 5.945 ns |	 0.86 |		0.05 | 0.0455 |		144 B |
|		  |		 |		   |		   |		  |			 |		  |			 |		  |			  |
| Default | Core |	  Core | 107.76 ns | 2.183 ns | 2.144 ns |	 1.00 |		0.00 | 0.0457 |		144 B |
|	  New | Core |	  Core |  82.49 ns | 1.721 ns | 2.048 ns |	 0.77 |		0.02 | 0.0228 |		 72 B |


### Encode Data

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742189 Hz, Resolution=364.6722 ns, Timer=TSC
.NET Core SDK=2.1.300-preview3-008384
  [Host] : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT
  Clr	 : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  Core	 : .NET Core 2.1.0-preview2-26313-01 (CoreCLR 4.6.26310.01, CoreFX 4.6.26313.01), 64bit RyuJIT


```
|  Method |	 Job | Runtime | DataSize |		 Mean |		Error |	   StdDev | Scaled | ScaledSD |	 Gen 0 | Allocated |
|-------- |----- |-------- |--------- |----------:|----------:|----------:|-------:|---------:|-------:|----------:|
| **Default** |	 **Clr** |	   **Clr** |	   **10** |	 **99.66 ns** |	 **2.085 ns** |	 **4.259 ns** |	  **1.00** |	 **0.00** | **0.0355** |	 **112 B** |
|	  New |	 Clr |	   Clr |	   10 |	 96.82 ns |	 1.934 ns |	 1.986 ns |	  0.97 |	 0.04 | 0.0355 |	 112 B |
|		  |		 |		   |		  |			  |			  |			  |		   |		  |		   |		   |
| Default | Core |	  Core |	   10 |	 94.31 ns |	 1.966 ns |	 5.178 ns |	  1.00 |	 0.00 | 0.0355 |	 112 B |
|	  New | Core |	  Core |	   10 |	 85.06 ns |	 1.768 ns |	 2.479 ns |	  0.90 |	 0.05 | 0.0178 |	  56 B |
|		  |		 |		   |		  |			  |			  |			  |		   |		  |		   |		   |
| **Default** |	 **Clr** |	   **Clr** |	   **50** | **292.39 ns** |	 **1.660 ns** |	 **1.472 ns** |	  **1.00** |	 **0.00** | **0.1016** |	 **320 B** |
|	  New |	 Clr |	   Clr |	   50 | 242.92 ns |	 4.917 ns | 10.897 ns |	  0.83 |	 0.04 | 0.1016 |	 320 B |
|		  |		 |		   |		  |			  |			  |			  |		   |		  |		   |		   |
| Default | Core |	  Core |	   50 | 240.90 ns |	 4.883 ns |	 4.796 ns |	  1.00 |	 0.00 | 0.1016 |	 320 B |
|	  New | Core |	  Core |	   50 | 151.45 ns |	 3.082 ns |	 5.479 ns |	  0.63 |	 0.03 | 0.0508 |	 160 B |
|		  |		 |		   |		  |			  |			  |			  |		   |		  |		   |		   |
| **Default** |	 **Clr** |	   **Clr** |	  **100** | **557.73 ns** | **10.927 ns** | **13.008 ns** |	  **1.00** |	 **0.00** | **0.1879** |	 **592 B** |
|	  New |	 Clr |	   Clr |	  100 | 431.71 ns |	 7.723 ns |	 6.846 ns |	  0.77 |	 0.02 | 0.1879 |	 592 B |
|		  |		 |		   |		  |			  |			  |			  |		   |		  |		   |		   |
| Default | Core |	  Core |	  100 | 467.78 ns |	 9.396 ns | 19.614 ns |	  1.00 |	 0.00 | 0.1879 |	 592 B |
|	  New | Core |	  Core |	  100 | 326.64 ns |	 6.474 ns |	 5.739 ns |	  0.70 |	 0.03 | 0.0939 |	 296 B |


# Notes

## Prospects

There could be a ~20% perf-win, when the base64-encoding / -decoding step would convert directly to / from url-encoded form by changing the base64-character map.
But by doing so we would "duplicate" the methods from `Base64`-class. This PR does rely on the provided methods -- maybe a follow-up PR will handle this.

## Private classes

In a normal project I would separate the private classes to their own files, but here the `WebEncoders.cs` is a linked file, so I stuffed everything in this file. 
