### PR TITLE
Don't unpin MemoryPoolSlab while in use

### DIFF
--- a/shared/Microsoft.Extensions.Buffers.Sources/MemoryPoolBlock.Debug.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/MemoryPoolBlock.Debug.cs
@@ -74,14 +74,19 @@ namespace System.Buffers
 
         protected override void Dispose(bool disposing)
         {
-            if (!Slab.IsActive) ThrowHelper.ThrowObjectDisposedException(ExceptionArgument.MemoryPoolBlock);
-
             if (Volatile.Read(ref _pinCount) > 0)
             {
                 ThrowHelper.ThrowInvalidOperationException_ReturningPinnedBlock();
             }
 
-            Pool.Return(this);
+            if (Slab.IsActive)
+            {
+                Pool.Return(this);
+            }
+            else
+            {
+                Slab.Return(this);
+            }
         }
 
         public override Span<byte> GetSpan() => new Span<byte>(Slab.Array, _offset, _length);

--- a/shared/Microsoft.Extensions.Buffers.Sources/MemoryPoolBlock.Release.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/MemoryPoolBlock.Release.cs
@@ -53,8 +53,14 @@ namespace System.Buffers
 
         public void Dispose()
         {
-            if (!Slab.IsActive) ThrowHelper.ThrowObjectDisposedException(ExceptionArgument.MemoryPoolBlock);
-            Pool.Return(this);
+            if (Slab.IsActive)
+            {
+                Pool.Return(this);
+            }
+            else
+            {
+                Slab.Return(this);
+            }
         }
 
         public void Lease()

--- a/shared/Microsoft.Extensions.Buffers.Sources/MemoryPoolSlab.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/MemoryPoolSlab.cs
@@ -77,6 +77,12 @@ namespace System.Buffers
                 _isActive = false;
 
                 _disposedValue = true;
+#if DEBUG
+                if (_ownedBlocks != 0)
+                {
+                    throw new InvalidOperationException("MemoryPoolBlocks still outstanding!");
+                }
+#endif
             }
         }
 

--- a/shared/Microsoft.Extensions.Buffers.Sources/SlabMemoryPool.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/SlabMemoryPool.cs
@@ -104,6 +104,7 @@ namespace System.Buffers
             // Ensure page aligned
             Debug.Assert((((ulong)basePtr + (uint)firstOffset) & (uint)(_blockSize - 1)) == 0);
 
+            var blocksCreated = 0;
             var blockAllocationLength = ((_slabLength - firstOffset) & ~(_blockSize - 1));
             var offset = firstOffset;
             for (;
@@ -119,9 +120,12 @@ namespace System.Buffers
                 block.IsLeased = true;
 #endif
                 Return(block);
+                blocksCreated++;
             }
 
             Debug.Assert(offset + _blockSize - firstOffset == blockAllocationLength);
+
+            slab.OwnedBlocks = blocksCreated + 1;
             // return last block rather than adding to pool
             var newBlock = new MemoryPoolBlock(
                     this,


### PR DESCRIPTION
May cause heap corruption re: https://github.com/aspnet/Common/pull/332#discussion_r183229246

Currently it Unpins, then a block is returned which throws an ODE exception https://github.com/aspnet/KestrelHttpServer/issues/2486
```
Log Critical[0]: Unexpected exception in HttpConnection.ProcessRequestsAsync. System.ObjectDisposedException: Cannot access a disposed object.
[20:27:03]	Object name: 'MemoryPoolBlock'.
[20:27:03]	at System.Buffers.ThrowHelper.ThrowObjectDisposedException(ExceptionArgument argument) in D:\b\w\1e8cd6334ef22651\packages\microsoft.extensions.buffers.sources\2.1.0-preview3-32110\contentFiles\cs\netstandard1.0\Microsoft.Extensions.Buffers.Sources\PipelinesThrowHelper.cs:line 51
[20:27:03]	at System.Buffers.MemoryPoolBlock.Dispose() in D:\b\w\1e8cd6334ef22651\packages\microsoft.extensions.buffers.sources\2.1.0-preview3-32110\contentFiles\cs\netstandard1.0\Microsoft.Extensions.Buffers.Sources\MemoryPoolBlock.Release.cs:line 54
[20:27:03]	at System.IO.Pipelines.BufferSegment.ResetMemory()
[20:27:03]	at System.IO.Pipelines.Pipe.CompletePipe()
[20:27:03]	at System.IO.Pipelines.Pipe.CompleteWriter(Exception exception)
[20:27:03]	at Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.AdaptedPipeline.ReadInputAsync(Stream stream)
[20:27:03]	at Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.AdaptedPipeline.RunAsync(Stream stream) in D:\b\w\1e8cd6334ef22651\src\Kestrel.Core\Adapter\Internal\AdaptedPipeline.cs:line 45
[20:27:03]	at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.HttpConnection.ProcessRequestsAsync[TContext](IHttpApplication`1 httpApplication) in D:\b\w\1e8cd6334ef22651\src\Kestrel.Core\Internal\HttpConnection.cs:line 183
``` 
Probably bad things also happen as the data block would now be using unpinned memory, with a long previously captured pointer... Like heap corruption? https://github.com/aspnet/KestrelHttpServer/issues/2503 https://github.com/dotnet/coreclr/issues/17679

New spin on this; is the change https://github.com/aspnet/Common/pull/332 started throwing ODE exceptions, whereas previously it didn't do, so that may have been where the GC crash leading to hangs surfaced in the error handling/unwind?

Resolves https://github.com/aspnet/KestrelHttpServer/issues/2486 (Test timeout: MemoryPoolBlock ObjectDisposedException)

/cc @pakrym @davidfowl @GrabYourPitchforks @mikeharder @jkotas