### PR TITLE
Support skipping tests with missing data.

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/xunit/ConditionalTheoryDiscoverer.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/ConditionalTheoryDiscoverer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -12,6 +13,24 @@ namespace Microsoft.AspNetCore.Testing.xunit
         public ConditionalTheoryDiscoverer(IMessageSink diagnosticMessageSink)
             : base(diagnosticMessageSink)
         {
+        }
+
+        public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            var testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
+            // Xunit evaluates MemeberData before skip conditions. If there is no member data it returns an error test case.
+            // However we have some cases where we conditionally expect no MemeberData and we set skip conditions accordingly.
+            // E.g. All of the test cases are excluded on a specific OS. In other words, don't fail if it was going to be skipped anyways.
+            // We don't always do this because we want to show the individual test cases as skipped where possible.
+            if (testCases.Count() == 1 && testCases.First() is ExecutionErrorTestCase)
+            {
+                var skipReason = testMethod.EvaluateSkipConditions();
+                if (skipReason != null)
+                {
+                    return new[] { new SkippedTestCase(skipReason, DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+                }
+            }
+            return testCases;
         }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)

--- a/test/Microsoft.AspNetCore.Testing.Tests/ConditionalTheoryTest.cs
+++ b/test/Microsoft.AspNetCore.Testing.Tests/ConditionalTheoryTest.cs
@@ -64,6 +64,17 @@ namespace Microsoft.AspNetCore.Testing
             => new TheoryData<int> { 0, 1 };
 
         [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX | OperatingSystems.Linux)]
+        [MemberData(nameof(GetNoInts))]
+        public void ConditionalTheoriesWithEmptyMemberDataStillSkipped(int arg)
+        {
+            Assert.True(false, "This should never run");
+        }
+
+        public static TheoryData<int> GetNoInts
+            => new TheoryData<int> { };
+
+        [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Windows)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Linux)]


### PR DESCRIPTION
Xunit evaluates MemeberData before we get a chance to evaluate skip conditions. If there is no member data it returns an error test case. However we have some cases where we conditionally expect no MemeberData and we set skip conditions accordingly. E.g. All of the test cases are excluded on a specific OS. In other words, don't fail if it was going to be skipped anyways. We don't always do this because we want to show the individual test cases as skipped where possible.

Found as part of https://github.com/aspnet/ServerTests/pull/120