### PR TITLE
Split BufferReader.Advance with fast path

### DIFF
--- a/shared/Microsoft.Extensions.Buffers.Sources/BufferReader.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/BufferReader.cs
@@ -90,15 +90,34 @@ namespace System.Buffers
             _end = true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance(int byteCount)
         {
-            if (byteCount < 0)
+            if (byteCount == 0)
+            {
+                return;
+            }
+            if (byteCount < 0 || _end)
             {
                 BuffersThrowHelper.ThrowArgumentOutOfRangeException(BuffersThrowHelper.ExceptionArgument.length);
             }
 
             _consumedBytes += byteCount;
 
+            if ((_index + byteCount) < _currentSpan.Length)
+            {
+                _index += byteCount;
+                byteCount = 0;
+            }
+            else
+            {
+                AdvanceNext(byteCount);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AdvanceNext(int byteCount)
+        {
             while (!_end && byteCount > 0)
             {
                 if ((_index + byteCount) < _currentSpan.Length)

--- a/shared/Microsoft.Extensions.Buffers.Sources/BufferReader.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/BufferReader.cs
@@ -107,7 +107,6 @@ namespace System.Buffers
             if ((_index + byteCount) < _currentSpan.Length)
             {
                 _index += byteCount;
-                byteCount = 0;
             }
             else
             {


### PR DESCRIPTION
MoveNext path is infrequently called (Advance 36M calls to MoveNext 568k calls)

![image](https://user-images.githubusercontent.com/1142958/40065225-31a64088-5859-11e8-98ce-6c8ea8980779.png)

9M MoveNext is from the .ctor

/cc @pakrym @davidfowl 