### PR TITLE
Buffer Reader.Advance move all exceptional cases to slow path

### DIFF
--- a/shared/Microsoft.Extensions.Buffers.Sources/BufferReader.cs
+++ b/shared/Microsoft.Extensions.Buffers.Sources/BufferReader.cs
@@ -93,19 +93,9 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance(int byteCount)
         {
-            if (byteCount == 0)
+            if (!_end && byteCount > 0 && (_index + byteCount) < _currentSpan.Length)
             {
-                return;
-            }
-            if (byteCount < 0 || _end)
-            {
-                BuffersThrowHelper.ThrowArgumentOutOfRangeException(BuffersThrowHelper.ExceptionArgument.length);
-            }
-
-            _consumedBytes += byteCount;
-
-            if ((_index + byteCount) < _currentSpan.Length)
-            {
+                _consumedBytes += byteCount;
                 _index += byteCount;
             }
             else
@@ -117,6 +107,13 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void AdvanceNext(int byteCount)
         {
+            if (byteCount < 0)
+            {
+                BuffersThrowHelper.ThrowArgumentOutOfRangeException(BuffersThrowHelper.ExceptionArgument.length);
+            }
+
+            _consumedBytes += byteCount;
+
             while (!_end && byteCount > 0)
             {
                 if ((_index + byteCount) < _currentSpan.Length)


### PR DESCRIPTION
`byteCount == 0`* and throwing exceptions now all handled by the slow path

*cos if you are calling Advance with `0` you don't care about performance...

/cc @davidfowl @pakrym 