### PR TITLE
Specific config for benchmarks at command line

### DIFF
--- a/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/AspNetCoreBenchmarkAttribute.cs
+++ b/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/AspNetCoreBenchmarkAttribute.cs
@@ -2,38 +2,70 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Reflection;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
+using System.Collections.Generic;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Toolchains.InProcess;
 
 namespace BenchmarkDotNet.Attributes
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     internal class AspNetCoreBenchmarkAttribute : Attribute, IConfigSource
     {
-        public static bool UseValidationConfig { get; set; }
-
-        public Type ConfigType { get; }
-        public Type ValidationConfigType { get; }
-
-        public AspNetCoreBenchmarkAttribute() : this(typeof(DefaultCoreConfig))
+        public AspNetCoreBenchmarkAttribute()
+            : this(typeof(DefaultCoreConfig))
         {
         }
 
-        public AspNetCoreBenchmarkAttribute(Type configType) : this(configType, typeof(DefaultCoreValidationConfig))
+        public AspNetCoreBenchmarkAttribute(Type configType)
+            : this(configType, typeof(DefaultCoreValidationConfig))
         {
         }
 
         public AspNetCoreBenchmarkAttribute(Type configType, Type validationConfigType)
         {
-            ConfigType = configType;
-            ValidationConfigType = validationConfigType;
+            ConfigTypes = new Dictionary<string, Type>()
+            {
+                { NamedConfiguration.Default, typeof(DefaultCoreConfig) },
+                { NamedConfiguration.Validation, typeof(DefaultCoreValidationConfig) },
+                { NamedConfiguration.Profile, typeof(DefaultCoreProfileConfig) },
+                { NamedConfiguration.Debug, typeof(DefaultCoreDebugConfig) },
+            };
+
+            if (configType != null)
+            {
+                ConfigTypes[NamedConfiguration.Default] = configType;
+            }
+
+            if (validationConfigType != null)
+            {
+                ConfigTypes[NamedConfiguration.Validation] = validationConfigType;
+            }
         }
 
-        public IConfig Config => (IConfig) Activator.CreateInstance(UseValidationConfig ? ValidationConfigType : ConfigType, Array.Empty<object>());
+        public IConfig Config
+        {
+            get
+            {
+                if (!ConfigTypes.TryGetValue(ConfigName ?? NamedConfiguration.Default, out var configType))
+                {
+                    var message = $"Could not find a configuration matching {ConfigName}. " +
+                        $"Known configurations: {string.Join(", ", ConfigTypes.Keys)}";
+                    throw new InvalidOperationException(message);
+                }
+                
+                return (IConfig)Activator.CreateInstance(configType, Array.Empty<object>());
+            }
+        }
+
+        public Dictionary<string, Type> ConfigTypes { get; }
+
+        public static string ConfigName { get; set; } = NamedConfiguration.Default;
+
+        public static class NamedConfiguration
+        {
+            public static readonly string Default = "default";
+            public static readonly string Validation = "validation";
+            public static readonly string Profile = "profile";
+            public static readonly string Debug = "debug";
+        }
     }
 }

--- a/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/DefaultCoreDebugConfig.cs
+++ b/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/DefaultCoreDebugConfig.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Validators;
+
+namespace BenchmarkDotNet.Attributes
+{
+    internal class DefaultCoreDebugConfig : ManualConfig
+    {
+        public DefaultCoreDebugConfig()
+        {
+            Add(ConsoleLogger.Default);
+            Add(JitOptimizationsValidator.DontFailOnError);
+
+            Add(Job.InProcess
+                .With(RunStrategy.Throughput));
+        }
+    }
+}

--- a/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/DefaultCoreProfileConfig.cs
+++ b/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/DefaultCoreProfileConfig.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Validators;
+
+namespace BenchmarkDotNet.Attributes
+{
+    internal class DefaultCoreProfileConfig : ManualConfig
+    {
+        public DefaultCoreProfileConfig()
+        {
+            Add(ConsoleLogger.Default);
+            Add(MarkdownExporter.GitHub);
+
+            Add(MemoryDiagnoser.Default);
+            Add(StatisticColumn.OperationsPerSecond);
+            Add(DefaultColumnProviders.Instance);
+
+            Add(JitOptimizationsValidator.FailOnError);
+
+            Add(Job.InProcess
+                .With(RunStrategy.Throughput));
+        }
+    }
+}

--- a/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/Program.cs
+++ b/shared/Microsoft.AspNetCore.BenchmarkRunner.Sources/Program.cs
@@ -2,15 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Toolchains.InProcess;
+using BenchmarkDotNet.Running;
 
 namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
 {
@@ -25,7 +24,7 @@ namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
         {
             BeforeMain(args);
 
-            CheckValidate(ref args);
+            AssignConfiguration(ref args);
             var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly)
                 .Run(args, ManualConfig.CreateEmpty());
 
@@ -66,16 +65,35 @@ namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
             return 1;
         }
 
-        private static void CheckValidate(ref string[] args)
+        private static void AssignConfiguration(ref string[] args)
         {
             var argsList = args.ToList();
             if (argsList.Remove("--validate") || argsList.Remove("--validate-fast"))
             {
+                // Compat: support the old style of passing a config that is used by our build system.
                 SuppressConsole();
-                AspNetCoreBenchmarkAttribute.UseValidationConfig = true;
+                AspNetCoreBenchmarkAttribute.ConfigName = AspNetCoreBenchmarkAttribute.NamedConfiguration.Validation;
+                args = argsList.ToArray();
+                return;
+            }
+            
+            var index = argsList.IndexOf("--config");
+            if (index >= 0 && index < argsList.Count -1)
+            {
+                AspNetCoreBenchmarkAttribute.ConfigName = argsList[index + 1];
+                argsList.RemoveAt(index + 1);
+                argsList.RemoveAt(index);
+                args = argsList.ToArray();
+                return;
             }
 
-            args = argsList.ToArray();
+            if (Debugger.IsAttached)
+            {
+                Console.WriteLine("Using the debug config since you are debugging. I hope that's OK!");
+                Console.WriteLine("Specify a configuration with --config <name> to override");
+                AspNetCoreBenchmarkAttribute.ConfigName = AspNetCoreBenchmarkAttribute.NamedConfiguration.Debug;
+                return;
+            }
         }
 
         private static void SuppressConsole()


### PR DESCRIPTION
Adds a 'debug' and 'profile' config for benchmark.net as well as the
ability to parse the config from the command line.

Also, will default to 'debug' if you are debugging without otherwise
specifying.

The debug config is optimized for troubleshooting, so it allows you to
run debug bits and always runs in process.

The profile config is optimized for profiling, and runs your code in
process. This is ideal for launching from a tool like dotTrace.