### PR TITLE
HttpClientSlim exclude default port in host header

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/HttpClientSlim.cs
+++ b/src/Microsoft.AspNetCore.Testing/HttpClientSlim.cs
@@ -45,7 +45,14 @@ namespace Microsoft.AspNetCore.Testing
                 // Make sure there's no % scope id. https://github.com/aspnet/KestrelHttpServer/issues/2637
                 var address = IPAddress.Parse(requestUri.Host);
                 address = new IPAddress(address.GetAddressBytes()); // Drop scope Id.
-                authority = $"[{address}]:{requestUri.Port.ToString(CultureInfo.InvariantCulture)}";
+                if (requestUri.IsDefaultPort)
+                {
+                    authority = $"[{address}]";
+                }
+                else
+                {
+                    authority = $"[{address}]:{requestUri.Port.ToString(CultureInfo.InvariantCulture)}";
+                }
             }
             return authority;
         }

--- a/test/Microsoft.AspNetCore.Testing.Tests/HttpClientSlimTest.cs
+++ b/test/Microsoft.AspNetCore.Testing.Tests/HttpClientSlimTest.cs
@@ -59,6 +59,13 @@ namespace Microsoft.AspNetCore.Testing
             Assert.Equal("[fe80::5d2a:d070:6fd6:1bac]:5003", HttpClientSlim.GetHost(requestUri));
         }
 
+        [Fact]
+        public void GetHostExcludesDefaultPort()
+        {
+            var requestUri = new Uri("http://[fe80::5d2a:d070:6fd6:1bac%7]:80/");
+            Assert.Equal("[fe80::5d2a:d070:6fd6:1bac]", HttpClientSlim.GetHost(requestUri));
+        }
+
         private HttpListener StartHost(out string address, int statusCode = 200, Func<HttpListenerContext, Task> handler = null)
         {
             var listener = new HttpListener();


### PR DESCRIPTION
Follow up to https://github.com/aspnet/Common/pull/369 for some regressions in http://aspnetci/viewLog.html?buildId=480406&tab=buildResultsDiv&buildTypeId=Lite_KestrelStressTest

Clients should not include the default port in the host header.