### PR TITLE
Add certificate names for code-signing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,8 @@
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)build\Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
+    <PackageSigningCertName>MicrosoftNuGet</PackageSigningCertName>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Internal.AspNetCore.Analyzers/Internal.AspNetCore.Analyzers.csproj
+++ b/src/Internal.AspNetCore.Analyzers/Internal.AspNetCore.Analyzers.csproj
@@ -7,6 +7,9 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnableApiCheck>false</EnableApiCheck>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
+    <!-- Do not sign this package. -->
+    <AssemblySigningCertName />
+    <PackageSigningCertName />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add the name of the assembly and package signing certificates to be used. This information ends up in the signrequest.xml file so codesigning can run based on the manifest.

cc @ryanbrandenburg - I'm going to make this change in all aspnet/Universe repos