### PR TITLE
Don't capture AsyncLocals into CancellationChangeToken registration

### DIFF
--- a/src/Microsoft.Extensions.Primitives/CancellationChangeToken.cs
+++ b/src/Microsoft.Extensions.Primitives/CancellationChangeToken.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Extensions.Primitives
         {
             // Don't capture the current ExecutionContext and its AsyncLocals onto the token registration causing them to live forever
             var restoreFlow = false;
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
             try
             {
-                if (!ExecutionContext.IsFlowSuppressed())
-                {
-                    ExecutionContext.SuppressFlow();
-                    restoreFlow = true;
-                }
-
                 return Token.Register(callback, state);
             }
             catch (ObjectDisposedException)

--- a/src/Microsoft.Extensions.Primitives/CancellationChangeToken.cs
+++ b/src/Microsoft.Extensions.Primitives/CancellationChangeToken.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.Primitives
         public IDisposable RegisterChangeCallback(Action<object> callback, object state)
         {
             // Don't capture the current ExecutionContext and its AsyncLocals onto the token registration causing them to live forever
-            bool restoreFlow = false;
+            var restoreFlow = false;
             try
             {
                 if (!ExecutionContext.IsFlowSuppressed())
@@ -52,7 +52,9 @@ namespace Microsoft.Extensions.Primitives
             {
                 // Restore the current ExecutionContext
                 if (restoreFlow)
+                {
                     ExecutionContext.RestoreFlow();
+                }
             }
 
             return NullDisposable.Instance;

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -103,22 +103,16 @@ namespace Microsoft.Extensions.Primitives
             var asyncLocal = new AsyncLocal<int>();
             asyncLocal.Value = 1;
 
-            // Register Callbacks
-            cancellationChangeToken.RegisterChangeCallback(
-                al => Assert.Equal(0, ((AsyncLocal<int>)al).Value), // AsyncLocal not set, when run on clean context
+            // Register Callback
+            cancellationChangeToken.RegisterChangeCallback(al =>
+            {
+                // AsyncLocal not set, when run on clean context
                 // A suppressed flow runs in current context, rather than restoring the captured context
-                asyncLocal);
-
-            cancellationToken.Register(
-                al => Assert.Equal(1, ((AsyncLocal<int>)al).Value), // AsyncLocal set, even when run on clean context
-                // Non-suppressed flow will restore the context at registration
-                asyncLocal);
+                Assert.Equal(0, ((AsyncLocal<int>) al).Value);
+            }, asyncLocal);
 
             // AsyncLocal should still be set
             Assert.Equal(1, asyncLocal.Value);
-
-            // Change AsyncLocal so it differs from value used at registration
-            asyncLocal.Value = 2;
 
             // Check AsyncLocal is not restored by running on clean context
             ExecutionContext.Run(executionContext, cts => ((CancellationTokenSource)cts).Cancel(), cancellationTokenSource);

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.Primitives
             ExecutionContext.Run(executionContext, cts => ((CancellationTokenSource)cts).Cancel(), cancellationTokenSource);
 
             // AsyncLocal should still be set
-            Assert.Equal(2, asyncLocal.Value);
+            Assert.Equal(1, asyncLocal.Value);
         }
     }
 }

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using Xunit;
 
 namespace Microsoft.Extensions.Primitives
@@ -86,6 +87,38 @@ namespace Microsoft.Extensions.Primitives
             Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(2, count);
             Assert.NotNull(callbackState);
+        }
+
+        [Fact]
+        public void AsyncLocalsNotCapturedAndRestored()
+        {
+            // Capture clean context
+            var executionContext = ExecutionContext.Capture();
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken = cancellationTokenSource.Token;
+            var cancellationChangeToken = new CancellationChangeToken(cancellationToken);
+            
+            // Set AsyncLocal
+            var asyncLocal = new AsyncLocal<int>();
+            asyncLocal.Value = 1;
+
+            // Register Callback
+            cancellationChangeToken.RegisterChangeCallback(al =>
+            {
+                // AsyncLocal shouldn't be set, when run on clean context
+                // A suppressed flow runs in current context, rather than restoring the captured context
+                Assert.Equal(0, ((AsyncLocal<int>)al).Value);
+            }, asyncLocal);
+
+            // AsyncLocal should still be set
+            Assert.Equal(1, asyncLocal.Value);
+
+            // Check AsyncLocal is not restored by running on clean context
+            ExecutionContext.Run(executionContext, cts => ((CancellationTokenSource)cts).Cancel(), cancellationTokenSource);
+
+            // AsyncLocal should still be set
+            Assert.Equal(1, asyncLocal.Value);
         }
     }
 }

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -103,22 +103,28 @@ namespace Microsoft.Extensions.Primitives
             var asyncLocal = new AsyncLocal<int>();
             asyncLocal.Value = 1;
 
-            // Register Callback
-            cancellationChangeToken.RegisterChangeCallback(al =>
-            {
-                // AsyncLocal shouldn't be set, when run on clean context
+            // Register Callbacks
+            cancellationChangeToken.RegisterChangeCallback(
+                al => Assert.Equal(0, ((AsyncLocal<int>)al).Value), // AsyncLocal not set, when run on clean context
                 // A suppressed flow runs in current context, rather than restoring the captured context
-                Assert.Equal(0, ((AsyncLocal<int>)al).Value);
-            }, asyncLocal);
+                asyncLocal);
+
+            cancellationToken.Register(
+                al => Assert.Equal(1, ((AsyncLocal<int>)al).Value), // AsyncLocal set, even when run on clean context
+                // Non-suppressed flow will restore the context at registration
+                asyncLocal);
 
             // AsyncLocal should still be set
             Assert.Equal(1, asyncLocal.Value);
+
+            // Change AsyncLocal so it differs from value used at registration
+            asyncLocal.Value = 2;
 
             // Check AsyncLocal is not restored by running on clean context
             ExecutionContext.Run(executionContext, cts => ((CancellationTokenSource)cts).Cancel(), cancellationTokenSource);
 
             // AsyncLocal should still be set
-            Assert.Equal(1, asyncLocal.Value);
+            Assert.Equal(2, asyncLocal.Value);
         }
     }
 }

--- a/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
+++ b/test/Microsoft.Extensions.Primitives.Tests/ChangeTokenTest.cs
@@ -98,7 +98,8 @@ namespace Microsoft.Extensions.Primitives
             var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
             var cancellationChangeToken = new CancellationChangeToken(cancellationToken);
-            
+            var executed = false;
+
             // Set AsyncLocal
             var asyncLocal = new AsyncLocal<int>();
             asyncLocal.Value = 1;
@@ -109,6 +110,7 @@ namespace Microsoft.Extensions.Primitives
                 // AsyncLocal not set, when run on clean context
                 // A suppressed flow runs in current context, rather than restoring the captured context
                 Assert.Equal(0, ((AsyncLocal<int>) al).Value);
+                executed = true;
             }, asyncLocal);
 
             // AsyncLocal should still be set
@@ -119,6 +121,7 @@ namespace Microsoft.Extensions.Primitives
 
             // AsyncLocal should still be set
             Assert.Equal(1, asyncLocal.Value);
+            Assert.True(executed);
         }
     }
 }


### PR DESCRIPTION
This causes a problem with `IHttpContextAccessor` as it captures the `HttpContext` and everything linked to it causing a lot of memory to become rooted (as seen in https://github.com/aspnet/KestrelHttpServer/issues/2840#issuecomment-416034872)

![image](https://user-images.githubusercontent.com/1142958/44630322-3f0d0e00-a953-11e8-9424-803eb301474b.png)

/cc @davidfowl 