### PR TITLE
Fix aspnet/Home#3493

### DIFF
--- a/test/Microsoft.Extensions.ObjectPool.Test/DefaultObjectPoolTest.cs
+++ b/test/Microsoft.Extensions.ObjectPool.Test/DefaultObjectPoolTest.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.Extensions.ObjectPool.Test
+namespace Microsoft.Extensions.ObjectPool
 {
     public class DefaultObjectPoolTest
     {

--- a/test/Microsoft.Extensions.ObjectPool.Test/ThreadingTest.cs
+++ b/test/Microsoft.Extensions.ObjectPool.Test/ThreadingTest.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.Extensions.ObjectPool
+{
+    public class ThreadingTest
+    {
+        private CancellationTokenSource _cts;
+        private DefaultObjectPool<Item> _pool;
+        private bool _foundError;
+
+        [Fact]
+        public void RunThreadingTest()
+        {
+            _cts = new CancellationTokenSource();
+            _pool = new DefaultObjectPool<Item>(new DefaultPooledObjectPolicy<Item>(), 10);
+
+            var threads = new Thread[8];
+            for (var i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(Run);
+            }
+
+            for (var i = 0; i < threads.Length; i++)
+            {
+                threads[i].Start();
+            }
+
+            // Run for 1000ms
+            _cts.CancelAfter(1000);
+
+            // Wait for all threads to complete
+            for (var i = 0; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+
+            Assert.False(_foundError, "Race condition found. An item was shared across threads.");
+        }
+
+        private void Run()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                var obj = _pool.Get();
+                if (obj.i != 0)
+                {
+                    _foundError = true;
+                }
+                obj.i = 123;
+
+                var obj2 = _pool.Get();
+                if (obj2.i != 0)
+                {
+                    _foundError = true;
+                }
+                obj2.i = 321;
+
+                obj.Reset();
+                _pool.Return(obj);
+
+                obj2.Reset();
+                _pool.Return(obj2);
+            }
+        }
+        
+        private class Item
+        {
+            public int i = 0;
+
+            public void Reset()
+            {
+                i = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes: https://github.com/aspnet/home/issues/3493
There's a race condition that occurs when the compare-exchange is
contended on the last non-null item in `_items`. Control flow falls out
of the loop but `item` is still initialized with a non-null value.
 
## Customer Impact
This can cause an object to be returned from the pool, while also being held by the pool, resulting in the object in use simultaneously by multiple threads.
Any code in the framework using the object pool could have data corruption

One customer reported this issue:  

## Regression from?
2.0.0 ---- pass
2.1.0-preview1-final -- pass
2.1.0-preview2-final -- failed
… fails afterward ...

## Risk
Very low.
The fix is to move a return statement inside the loop and reduce the scope of a variable. 