### PR TITLE
Fix aspnet/Home#3493

### DIFF
--- a/src/Microsoft.Extensions.ObjectPool/DefaultObjectPool.cs
+++ b/src/Microsoft.Extensions.ObjectPool/DefaultObjectPool.cs
@@ -56,19 +56,18 @@ namespace Microsoft.Extensions.ObjectPool
         private T GetViaScan()
         {
             ObjectWrapper[] items = _items;
-            T item = null;
 
             for (var i = 0; i < items.Length; i++)
             {
-                item = items[i];
+                T item = items[i];
 
                 if (item != null && Interlocked.CompareExchange(ref items[i].Element, null, item) == item)
                 {
-                    break;
+                    return item;
                 }
             }
 
-            return item ?? Create();
+            return Create();
         }
 
         // Non-inline to improve its code quality as uncommon path


### PR DESCRIPTION
## Description
Fixes: https://github.com/aspnet/home/issues/3493
There's a race condition that occurs when the compare-exchange is
contended on the last non-null item in `_items`. Control flow falls out
of the loop but `item` is still initialized with a non-null value.
 
## Customer Impact
This can cause an object to be returned from the pool, while also being held by the pool, resulting in the object in use simultaneously by multiple threads.
Any code in the framework using the object pool could have data corruption

One customer reported this issue:  

## Regression from?
2.0.0 ---- pass
2.1.0-preview1-final -- pass
2.1.0-preview2-final -- failed
… fails afterward ...

## Risk
Very low.
The fix is to move a return statement inside the loop and reduce the scope of a variable. 