### PR TITLE
Updating branding to 2.1.6-servicing

### DIFF
--- a/version.props
+++ b/version.props
@@ -1,9 +1,9 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>2.1.2</VersionPrefix>
-    <VersionSuffix>rtm</VersionSuffix>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
+    <VersionPrefix>2.1.6</VersionPrefix>
+    <VersionSuffix>servicing</VersionSuffix>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND ('$(VersionSuffix)' == 'servicing' OR '$(VersionSuffix)' == 'rtm') ">$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'servicing' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
     <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>


### PR DESCRIPTION
Per discussion with our team, we want to make the following changes to versioning during servicing updates:

* The versioning on packages with ship with ASP.NET Core should be consistent
* (No change) on packages with changes in them ship during servicing updates
* Version caps are okay. For example, this repo is producing a patch for 2.1.6, so packages will be 2.1.6. It did not patch for 2.1.4 or 2.1.3 so those versions will be skipped.

This also includes another minor change: for consistency with the rest of the .NET Core teams, pre-release servicing builds will be 2.1.x-servicing-buildnumber.